### PR TITLE
CI: Use ruby/setup-ruby@v1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, '3.0']
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}
@@ -16,13 +16,10 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
-    - name: Install dependencies
-      run: |
-        gem install bundler
-        bundle install
+        bundler-cache: true # 'bundle install' and cache
     - name: Show Linux kernel version
       run: uname -r
     - name: Compile C-extension


### PR DESCRIPTION
This PR is a tiny improvement to the GitHub Actions setup.

In ruby/setup-ruby@v1, there is a caching feature, and this commit enables it. That Action is managed and developed by the Ruby community.

Minor: To avoid 3.0 ever being stringified as "3", we quote the "ruby" matrix element for Ruby 3.0.