### PR TITLE
Add // to uri scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Extralite includes an adapter for
 just use the `extralite` scheme instead of `sqlite`:
 
 ```ruby
-DB = Sequel.connect('extralite:blog.db')
+DB = Sequel.connect('extralite://blog.db')
 articles = DB[:articles]
 p articles.to_a
 ```


### PR DESCRIPTION
The Readme (and the blog post) are missing the `//` from the scheme delimiter, and as such `Sequel` was not connecting to the file correctly.

Can you also update the blog post?

```
[1] pry(main)> require 'sequel'
=> true
[2] pry(main)> db1 = Sequel.connect 'extralite:my.db'
=> #<Sequel::Extralite::Database: "extralite:my.db">
[3] pry(main)> db1.opts
=> {:max_connections=>1,
 :database=>"",  # <----
 :orig_opts=>{},
 :uri=>"extralite:my.db",
 :adapter=>"extralite",
 :adapter_class=>Sequel::Extralite::Database,
 :single_threaded=>false}
[4] pry(main)> db2 = Sequel.connect 'extralite://my.db'
=> #<Sequel::Extralite::Database: "extralite://my.db">
[5] pry(main)> db2.opts
=> {:database=>"my.db",   # <----
 :orig_opts=>{},
 :uri=>"extralite://my.db",
 :adapter=>"extralite",
 :adapter_class=>Sequel::Extralite::Database,
 :single_threaded=>false}
```