### PR TITLE
fix: error must be derived from ::StandardError

### DIFF
--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -417,7 +417,7 @@ void Init_ExtraliteDatabase() {
 
   rb_define_method(cDatabase, "prepare", Database_prepare, 1);
 
-  cError = rb_define_class_under(mExtralite, "Error", rb_eRuntimeError);
+  cError = rb_define_class_under(mExtralite, "Error", rb_eStandardError);
   cSQLError = rb_define_class_under(mExtralite, "SQLError", cError);
   cBusyError = rb_define_class_under(mExtralite, "BusyError", cError);
   rb_gc_register_mark_object(cError);

--- a/lib/extralite.rb
+++ b/lib/extralite.rb
@@ -3,7 +3,7 @@ require_relative './extralite_ext'
 # Extralite is a Ruby gem for working with SQLite databases
 module Extralite
   # A base class for Extralite exceptions
-  class Error < RuntimeError
+  class Error < ::StandardError
   end
 
   # An exception representing an SQL error emitted by SQLite


### PR DESCRIPTION
otherwise, it is incorrectly translated by `ActiveRecord::AbstractAdapter`

    # lib/active_record/connection_adapters/abstract_adapter.rb:589

    def translate_exception(exception, message)
      # override in derived class
      case exception
      when RuntimeError
        exception
      else
        ActiveRecord::StatementInvalid.new(message)
      end
    end

it also breaks compatibility with SQLite3 gem by much.