### PR TITLE
add db.interrupt support for long running queries

### DIFF
--- a/ext/extralite/common.c
+++ b/ext/extralite/common.c
@@ -243,6 +243,8 @@ int stmt_iterate(sqlite3_stmt *stmt, sqlite3 *db) {
       return 0;
     case SQLITE_BUSY:
       rb_raise(cBusyError, "Database is busy");
+    case SQLITE_INTERRUPT:
+      rb_raise(cError, "Query was interrupted");
     case SQLITE_ERROR:
       rb_raise(cSQLError, "%s", sqlite3_errmsg(db));
     default:


### PR DESCRIPTION
add `db.interrupt` support for long-running queries

    t = Thread.new do
      sleep 0.5
      @db.interrupt
    end
    
    n = 2**31
    # Extralite::Error: Invalid return code for sqlite3_step: 9
    assert_raises(Extralite::Error) {
      @db.query <<-SQL
        WITH RECURSIVE
          fibo (curr, next)
        AS
        ( SELECT 1,1
          UNION ALL
          SELECT next, curr+next FROM fibo
          LIMIT #{n} )
        SELECT curr, next FROM fibo LIMIT 1 OFFSET #{n}-1;
      SQL
    }
    t.join