### PR TITLE
add db.interrupt support for long running queries

### DIFF
--- a/ext/extralite/common.c
+++ b/ext/extralite/common.c
@@ -243,6 +243,8 @@ int stmt_iterate(sqlite3_stmt *stmt, sqlite3 *db) {
       return 0;
     case SQLITE_BUSY:
       rb_raise(cBusyError, "Database is busy");
+    case SQLITE_INTERRUPT:
+      rb_raise(cError, "Query was interrupted");
     case SQLITE_ERROR:
       rb_raise(cSQLError, "%s", sqlite3_errmsg(db));
     default:

--- a/ext/extralite/common.c
+++ b/ext/extralite/common.c
@@ -244,7 +244,7 @@ int stmt_iterate(sqlite3_stmt *stmt, sqlite3 *db) {
     case SQLITE_BUSY:
       rb_raise(cBusyError, "Database is busy");
     case SQLITE_INTERRUPT:
-      rb_raise(cError, "Query was interrupted");
+      rb_raise(cInterruptError, "Query was interrupted");
     case SQLITE_ERROR:
       rb_raise(cSQLError, "%s", sqlite3_errmsg(db));
     default:

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -25,6 +25,7 @@ extern VALUE cPreparedStatement;
 extern VALUE cError;
 extern VALUE cSQLError;
 extern VALUE cBusyError;
+extern VALUE cInterruptError;
 
 extern ID ID_KEYS;
 extern ID ID_NEW;

--- a/ext/extralite/extralite_ext.c
+++ b/ext/extralite/extralite_ext.c
@@ -1,7 +1,7 @@
 void Init_ExtraliteDatabase();
 void Init_ExtralitePreparedStatement();
 
-void Init_extralite_ext() {
+void Init_extralite_ext(void) {
   Init_ExtraliteDatabase();
   Init_ExtralitePreparedStatement();
 }

--- a/ext/extralite/prepared_statement.c
+++ b/ext/extralite/prepared_statement.c
@@ -283,7 +283,7 @@ VALUE PreparedStatement_closed_p(VALUE self) {
   return stmt->stmt ? Qfalse : Qtrue;
 }
 
-void Init_ExtralitePreparedStatement() {
+void Init_ExtralitePreparedStatement(void) {
   VALUE mExtralite = rb_define_module("Extralite");
 
   cPreparedStatement = rb_define_class_under(mExtralite, "PreparedStatement", rb_cObject);

--- a/lib/extralite.rb
+++ b/lib/extralite.rb
@@ -2,6 +2,10 @@ require_relative './extralite_ext'
 
 # Extralite is a Ruby gem for working with SQLite databases
 module Extralite
+  # The following class definitions are not really needed, as they're already
+  # defined in the C extension. We put them here for the sake of generating
+  # docs.
+
   # A base class for Extralite exceptions
   class Error < RuntimeError
   end
@@ -13,6 +17,11 @@ module Extralite
   # An exception raised when an SQLite database is busy (locked by another
   # thread or process)
   class BusyError < Error
+  end
+
+  # An exception raised when a query is interrupted by calling
+  # `Database#interrupt` from another thread
+  class InterruptError < Error
   end
 
   # An SQLite database

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -243,6 +243,29 @@ end
       { bar: 'bye' }
     ], @db.query('select * from foo')
   end
+
+  def test_interrupt
+    t = Thread.new do
+      sleep 0.5
+      @db.interrupt
+    end
+
+    n = 2**31
+    # Extralite::Error: Query was interrupted
+    assert_raises(Extralite::Error) {
+      @db.query <<-SQL
+        WITH RECURSIVE
+          fibo (curr, next)
+        AS
+        ( SELECT 1,1
+          UNION ALL
+          SELECT next, curr+next FROM fibo
+          LIMIT #{n} )
+        SELECT curr, next FROM fibo LIMIT 1 OFFSET #{n}-1;
+      SQL
+    }
+    t.join
+  end
 end
 
 class ScenarioTest < MiniTest::Test

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -251,8 +251,7 @@ end
     end
 
     n = 2**31
-    # Extralite::Error: Query was interrupted
-    assert_raises(Extralite::Error) {
+    assert_raises(Extralite::InterruptError) {
       @db.query <<-SQL
         WITH RECURSIVE
           fibo (curr, next)


### PR DESCRIPTION
add `db.interrupt` support for long-running queries

    t = Thread.new do
      sleep 0.5
      @db.interrupt
    end
    
    n = 2**31
    # extralite::error: query was interrupted
    assert_raises(Extralite::Error) {
      @db.query <<-SQL
        WITH RECURSIVE
          fibo (curr, next)
        AS
        ( SELECT 1,1
          UNION ALL
          SELECT next, curr+next FROM fibo
          LIMIT #{n} )
        SELECT curr, next FROM fibo LIMIT 1 OFFSET #{n}-1;
      SQL
    }
    t.join
