### PR TITLE
fix anonymous argument error in backup_sleep_without_gvl for some compilers

### DIFF
--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -422,7 +422,7 @@ void *backup_step_without_gvl(void *ptr) {
   return NULL;
 }
 
-void *backup_sleep_without_gvl(void *) {
+void *backup_sleep_without_gvl(void *unused) {
   sqlite3_sleep(BACKUP_SLEEP_MS);
   return NULL;
 }


### PR DESCRIPTION
Our CI/CD pipeline produces in its images:

    database.c: In function 'backup_sleep_without_gvl':
    database.c:425:1: error: parameter name omitted
     void *backup_sleep_without_gvl(void *) {
     ^~~~

as an alternative it can be replaced with accomp attr:

    void *backup_sleep_without_gvl(__attribute__((unused)) void *unused)