### PR TITLE
Implement external iteration

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Sharon Rosner
+Copyright (c) 2023 Sharon Rosner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,4 @@
-- [v] Rename PreparedStatement to Query
-- [v] Add optional bind params to `Query.new`, `Database#prepare`
-- [v] Add `next_xxx`, `each_xxx` methods
-- [v] Include `Enumerable` in `Iterator`
-- [v] Add `reset(bind_params)` method
+- [ ] Implement and test Iterator#to_a
 
 - [ ] Docs for Query and Iterator
 - [ ] Update README (include link to docs)
-- [ ] Implement and test Query#eof?
-- [ ] Implement and test Iterator#to_a

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
-- [ ] Rename PreparedStatement to Query
-- [ ] Add `next_xxx`, `each_xxx` methods
+- [v] Rename PreparedStatement to Query
+- [v] Add optional bind params to `Query.new`, `Database#prepare`
+- [v] Add `next_xxx`, `each_xxx` methods
 - [ ] Include `Enumerable`
-- [ ] Add `reset(bind_params)` method
-- [ ] Add optional bind params to `Database#prepare`
+- [v] Add `reset(bind_params)` method

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,2 @@
-- [ ] Docs for Query and Iterator
+- [ ] Test tracing on Query & Iterator, fix tracing to trace only on first iteration (instead of on reset)
 - [ ] Update README (include link to docs)

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,2 @@
-- [ ] Implement and test Iterator#to_a
-
 - [ ] Docs for Query and Iterator
 - [ ] Update README (include link to docs)

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,0 @@
-- [ ] Test tracing on Query & Iterator, fix tracing to trace only on first iteration (instead of on reset)
-- [ ] Update README (include link to docs)

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,10 @@
 - [v] Rename PreparedStatement to Query
 - [v] Add optional bind params to `Query.new`, `Database#prepare`
 - [v] Add `next_xxx`, `each_xxx` methods
-- [ ] Include `Enumerable`
+- [v] Include `Enumerable` in `Iterator`
 - [v] Add `reset(bind_params)` method
+
+- [ ] Docs for Query and Iterator
+- [ ] Update README (include link to docs)
+- [ ] Implement and test Query#eof?
+- [ ] Implement and test Iterator#to_a

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+- [ ] Rename PreparedStatement to Query
+- [ ] Add `next_xxx`, `each_xxx` methods
+- [ ] Include `Enumerable`
+- [ ] Add `reset(bind_params)` method
+- [ ] Add optional bind params to `Database#prepare`

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -398,12 +398,12 @@ VALUE Database_load_extension(VALUE self, VALUE path) {
 #endif
 
 /* call-seq:
- *   db.prepare(sql) -> Extralite::PreparedStatement
+ *   db.prepare(sql) -> Extralite::Query
  *
  * Creates a prepared statement with the given SQL query.
  */
 VALUE Database_prepare(VALUE self, VALUE sql) {
-  return rb_funcall(cPreparedStatement, ID_new, 2, self, sql);
+  return rb_funcall(cQuery, ID_new, 2, self, sql);
 }
 
 /* call-seq:

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -171,7 +171,7 @@ static inline VALUE Database_perform_query(int argc, VALUE *argv, VALUE self, VA
  * 
  * Query parameters to be bound to placeholders in the query can be specified as
  * a list of values or as a hash mapping parameter names to values. When
- * parameters are given as a least, the query should specify parameters using
+ * parameters are given as an array, the query should specify parameters using
  * `?`:
  * 
  *     db.query('select * from foo where x = ?', 42)
@@ -196,7 +196,7 @@ VALUE Database_query_hash(int argc, VALUE *argv, VALUE self) {
  *
  * Query parameters to be bound to placeholders in the query can be specified as
  * a list of values or as a hash mapping parameter names to values. When
- * parameters are given as a least, the query should specify parameters using
+ * parameters are given as an array, the query should specify parameters using
  * `?`:
  *
  *     db.query_ary('select * from foo where x = ?', 42)
@@ -220,7 +220,7 @@ VALUE Database_query_ary(int argc, VALUE *argv, VALUE self) {
  *
  * Query parameters to be bound to placeholders in the query can be specified as
  * a list of values or as a hash mapping parameter names to values. When
- * parameters are given as a least, the query should specify parameters using
+ * parameters are given as an array, the query should specify parameters using
  * `?`:
  *
  *     db.query_single_row('select * from foo where x = ?', 42)
@@ -245,7 +245,7 @@ VALUE Database_query_single_row(int argc, VALUE *argv, VALUE self) {
  *
  * Query parameters to be bound to placeholders in the query can be specified as
  * a list of values or as a hash mapping parameter names to values. When
- * parameters are given as a least, the query should specify parameters using
+ * parameters are given as an array, the query should specify parameters using
  * `?`:
  *
  *     db.query_single_column('select x from foo where x = ?', 42)
@@ -269,7 +269,7 @@ VALUE Database_query_single_column(int argc, VALUE *argv, VALUE self) {
  *
  * Query parameters to be bound to placeholders in the query can be specified as
  * a list of values or as a hash mapping parameter names to values. When
- * parameters are given as a least, the query should specify parameters using
+ * parameters are given as an array, the query should specify parameters using
  * `?`:
  *
  *     db.query_single_value('select x from foo where x = ?', 42)
@@ -297,7 +297,7 @@ VALUE Database_query_single_value(int argc, VALUE *argv, VALUE self) {
  *       [1, 2, 3],
  *       [4, 5, 6]
  *     ]
- *     db.execute_multi_query('insert into foo values (?, ?, ?)', records)
+ *     db.execute_multi('insert into foo values (?, ?, ?)', records)
  *
  */
 VALUE Database_execute_multi(VALUE self, VALUE sql, VALUE params_array) {

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -7,6 +7,7 @@ VALUE cSQLError;
 VALUE cBusyError;
 VALUE cInterruptError;
 
+ID ID_bind;
 ID ID_call;
 ID ID_keys;
 ID ID_new;
@@ -155,7 +156,7 @@ static inline VALUE Database_perform_query(int argc, VALUE *argv, VALUE self, VA
   RB_GC_GUARD(sql);
 
   bind_all_parameters(stmt, argc - 1, argv + 1);
-  query_ctx ctx = { self, db->sqlite3_db, stmt };
+  query_ctx ctx = { self, db->sqlite3_db, stmt, Qnil, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS };
 
   return rb_ensure(SAFE(call), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -308,7 +309,7 @@ VALUE Database_execute_multi(VALUE self, VALUE sql, VALUE params_array) {
   // prepare query ctx
   GetOpenDatabase(self, db);
   prepare_single_stmt(db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = { self, db->sqlite3_db, stmt, params_array };
+  query_ctx ctx = { self, db->sqlite3_db, stmt, params_array, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS };
 
   return rb_ensure(SAFE(safe_execute_multi), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -402,8 +403,12 @@ VALUE Database_load_extension(VALUE self, VALUE path) {
  *
  * Creates a prepared statement with the given SQL query.
  */
-VALUE Database_prepare(VALUE self, VALUE sql) {
-  return rb_funcall(cQuery, ID_new, 2, self, sql);
+VALUE Database_prepare(int argc, VALUE *argv, VALUE self) {
+  rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
+  VALUE query = rb_funcall(cQuery, ID_new, 2, self, argv[0]);
+  if (argc > 1) rb_funcallv(query, ID_bind, argc - 1, argv + 1);
+  RB_GC_GUARD(query);
+  return query;
 }
 
 /* call-seq:
@@ -717,7 +722,7 @@ void Init_ExtraliteDatabase(void) {
   rb_define_method(cDatabase, "interrupt", Database_interrupt, 0);
   rb_define_method(cDatabase, "last_insert_rowid", Database_last_insert_rowid, 0);
   rb_define_method(cDatabase, "limit", Database_limit, -1);
-  rb_define_method(cDatabase, "prepare", Database_prepare, 1);
+  rb_define_method(cDatabase, "prepare", Database_prepare, -1);
   rb_define_method(cDatabase, "query", Database_query_hash, -1);
   rb_define_method(cDatabase, "query_ary", Database_query_ary, -1);
   rb_define_method(cDatabase, "query_hash", Database_query_hash, -1);
@@ -742,6 +747,7 @@ void Init_ExtraliteDatabase(void) {
   rb_gc_register_mark_object(cBusyError);
   rb_gc_register_mark_object(cInterruptError);
 
+  ID_bind   = rb_intern("bind");
   ID_call   = rb_intern("call");
   ID_keys   = rb_intern("keys");
   ID_new    = rb_intern("new");

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -108,6 +108,10 @@ VALUE Query_next_hash(int argc, VALUE *argv, VALUE self);
 VALUE Query_next_ary(int argc, VALUE *argv, VALUE self);
 VALUE Query_next_single_column(int argc, VALUE *argv, VALUE self);
 
+VALUE Query_to_a_hash(VALUE self);
+VALUE Query_to_a_ary(VALUE self);
+VALUE Query_to_a_single_column(VALUE self);
+
 void prepare_single_stmt(sqlite3 *db, sqlite3_stmt **stmt, VALUE sql);
 void prepare_multi_stmt(sqlite3 *db, sqlite3_stmt **stmt, VALUE sql);
 void bind_all_parameters(sqlite3_stmt *stmt, int argc, VALUE *argv);

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -20,7 +20,7 @@
 #define SAFE(f) (VALUE (*)(VALUE))(f)
 
 extern VALUE cDatabase;
-extern VALUE cPreparedStatement;
+extern VALUE cQuery;
 
 extern VALUE cError;
 extern VALUE cSQLError;
@@ -35,29 +35,32 @@ extern ID ID_to_s;
 
 typedef struct {
   sqlite3 *sqlite3_db;
-  VALUE trace_block;
+  VALUE   trace_block;
 } Database_t;
 
 typedef struct {
-  VALUE db;
-  VALUE sql;
-  Database_t *db_struct;
-  sqlite3 *sqlite3_db;
-  sqlite3_stmt *stmt;
-} PreparedStatement_t;
+  VALUE         db;
+  VALUE         sql;
+  Database_t    *db_struct;
+  sqlite3       *sqlite3_db;
+  sqlite3_stmt  *stmt;
+  int           closed;
+} Query_t;
 
 typedef struct {
-  VALUE self;
-  sqlite3 *sqlite3_db;
-  sqlite3_stmt *stmt;
-  VALUE params;
+  VALUE         self;
+  sqlite3       *sqlite3_db;
+  sqlite3_stmt  *stmt;
+  VALUE         params;
 } query_ctx;
 
 typedef struct {
-  VALUE dst;
-  VALUE src;
-  sqlite3_backup *p;
+  VALUE           dst;
+  VALUE           src;
+  sqlite3_backup  *p;
 } backup_t;
+
+#define TUPLE_MAX_EMBEDDED_VALUES 20
 
 VALUE safe_execute_multi(query_ctx *ctx);
 VALUE safe_query_ary(query_ctx *ctx);

--- a/ext/extralite/extralite_ext.c
+++ b/ext/extralite/extralite_ext.c
@@ -1,7 +1,7 @@
 void Init_ExtraliteDatabase();
-void Init_ExtralitePreparedStatement();
+void Init_ExtraliteQuery();
 
 void Init_extralite_ext(void) {
   Init_ExtraliteDatabase();
-  Init_ExtralitePreparedStatement();
+  Init_ExtraliteQuery();
 }

--- a/ext/extralite/extralite_ext.c
+++ b/ext/extralite/extralite_ext.c
@@ -1,7 +1,9 @@
 void Init_ExtraliteDatabase();
 void Init_ExtraliteQuery();
+void Init_ExtraliteIterator();
 
 void Init_extralite_ext(void) {
   Init_ExtraliteDatabase();
   Init_ExtraliteQuery();
+  Init_ExtraliteIterator();
 }

--- a/ext/extralite/iterator.c
+++ b/ext/extralite/iterator.c
@@ -1,0 +1,123 @@
+#include <stdio.h>
+#include "extralite.h"
+
+/*
+ * Document-class: Extralite::Iterator
+ *
+ * This class implements an iterator used to iterate through query results.
+ */
+
+VALUE cIterator;
+
+VALUE SYM_hash;
+VALUE SYM_ary;
+VALUE SYM_single_column;
+
+static size_t Iterator_size(const void *ptr) {
+  return sizeof(Iterator_t);
+}
+
+static void Iterator_mark(void *ptr) {
+  Iterator_t *iterator = ptr;
+  rb_gc_mark(iterator->query);
+}
+
+static const rb_data_type_t Iterator_type = {
+    "Iterator",
+    {Iterator_mark, free, Iterator_size,},
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static VALUE Iterator_allocate(VALUE klass) {
+  Iterator_t *iterator = ALLOC(Iterator_t);
+  iterator->query = Qnil;
+  return TypedData_Wrap_Struct(klass, &Iterator_type, iterator);
+}
+
+static inline Iterator_t *value_to_iterator(VALUE obj) {
+  Iterator_t *iterator;
+  TypedData_Get_Struct((obj), Iterator_t, &Iterator_type, (iterator));
+  return iterator;
+}
+
+static inline enum iterator_mode symbol_to_mode(VALUE sym) {
+  if (sym == SYM_hash) return ITERATOR_HASH;
+  if (sym == SYM_ary) return ITERATOR_ARY;
+  if (sym == SYM_single_column) return ITERATOR_SINGLE_COLUMN;
+
+  rb_raise(cError, "Invalid iterator mode");
+}
+
+/* call-seq: initialize(query, mode)
+ *
+ * Initializes a new iterator
+ */
+VALUE Iterator_initialize(VALUE self, VALUE query, VALUE mode) {
+  Iterator_t *iterator = value_to_iterator(self);
+
+  iterator->query = query;
+  iterator->mode = symbol_to_mode(mode);
+
+  return Qnil;
+}
+
+typedef VALUE (*each_method)(VALUE);
+
+inline each_method mode_to_each_method(enum iterator_mode mode) {
+  switch (mode) {
+    case ITERATOR_ARY:
+      return Query_each_ary;
+    case ITERATOR_SINGLE_COLUMN:
+      return Query_each_single_column;
+    default:
+      return Query_each_hash;
+  }
+}
+
+VALUE Iterator_each(VALUE self) {
+  if (rb_block_given_p()) {
+    Iterator_t *iterator = value_to_iterator(self);
+    each_method method = mode_to_each_method(iterator->mode);
+    method(iterator->query);
+  }
+
+  return self;
+}
+
+typedef VALUE (*next_method)(int, VALUE *, VALUE);
+
+inline next_method mode_to_next_method(enum iterator_mode mode) {
+  switch (mode) {
+    case ITERATOR_ARY:
+      return Query_next_ary;
+    case ITERATOR_SINGLE_COLUMN:
+      return Query_next_single_column;
+    default:
+      return Query_next_hash;
+  }
+}
+
+VALUE Iterator_next(int argc, VALUE *argv, VALUE self) {
+  Iterator_t *iterator = value_to_iterator(self);
+  next_method method = mode_to_next_method(iterator->mode);
+  VALUE result = method(argc, argv, iterator->query);
+
+  return rb_block_given_p() ? self : result;
+}
+
+void Init_ExtraliteIterator(void) {
+  VALUE mExtralite = rb_define_module("Extralite");
+
+  cIterator = rb_define_class_under(mExtralite, "Iterator", rb_cObject);
+  rb_define_alloc_func(cIterator, Iterator_allocate);
+
+  rb_include_module(cIterator, rb_mEnumerable);
+
+  rb_define_method(cIterator, "initialize", Iterator_initialize, 2);
+  rb_define_method(cIterator, "each", Iterator_each, 0);
+  rb_define_method(cIterator, "next", Iterator_next, -1);
+
+  SYM_hash          = ID2SYM(rb_intern("hash"));
+  SYM_ary           = ID2SYM(rb_intern("ary"));
+  SYM_single_column = ID2SYM(rb_intern("single_column"));
+}

--- a/ext/extralite/iterator.c
+++ b/ext/extralite/iterator.c
@@ -48,9 +48,17 @@ static inline enum iterator_mode symbol_to_mode(VALUE sym) {
   rb_raise(cError, "Invalid iterator mode");
 }
 
-/* call-seq: initialize(query, mode)
+/* Initializes an iterator using the given query object and iteration mode. The
+ * iteration mode is one of: `:hash`, `:ary`, or `:single_column`. An iterator
+ * is normally returned from one of the methods `Query#each`/`Query#each_hash`,
+ * `Query#each_ary` or `Query#each_single_column` when called without a block:
+ * 
+ *     iterator = query.each
+ *     ...
  *
- * Initializes a new iterator
+ * @param query [Extralite::Query] associated query
+ * @param mode [Symbol] iteration mode
+ * @return [void]
  */
 VALUE Iterator_initialize(VALUE self, VALUE query, VALUE mode) {
   Iterator_t *iterator = value_to_iterator(self);
@@ -74,6 +82,14 @@ inline each_method mode_to_each_method(enum iterator_mode mode) {
   }
 }
 
+/* Iterates through the associated query's result set using the iteration mode
+ * set when initialized. Each row would be passed to the given block according
+ * to the iteration mode, i.e. as a hash, an array, or a single value. In
+ * `:single column` mode an error will be raised if the result sets contains
+ * more than one columns.
+ *
+ * @return [Extralite::Iterator] self
+ */
 VALUE Iterator_each(VALUE self) {
   if (rb_block_given_p()) {
     Iterator_t *iterator = value_to_iterator(self);
@@ -97,6 +113,22 @@ inline next_method mode_to_next_method(enum iterator_mode mode) {
   }
 }
 
+/* Returns the next 1 or more rows from the associated query's result set
+ * according to the iteration mode, i.e. as a hash, an array or a single value.
+ * 
+ * If no row count is given, a single row is returned. If a row count is given,
+ * an array containing up to the `row_count` rows is returned. If `row_count` is
+ * -1, all rows are returned. If the end of the result set has been reached,
+ * `nil` is returned.
+ * 
+ * If a block is given, rows are passed to the block and self is returned.
+ *
+ * @overload next()
+ *   @return [Hash, Array, Object, Extralite::Iterator] next row or self if block is given
+ * @overload next(row_count)
+ *   @param row_count [Integer] maximum row count or -1 for all rows
+ *   @return [Array, Extralite::Iterator] next rows or self if block is given
+ */
 VALUE Iterator_next(int argc, VALUE *argv, VALUE self) {
   Iterator_t *iterator = value_to_iterator(self);
   next_method method = mode_to_next_method(iterator->mode);
@@ -118,6 +150,11 @@ inline to_a_method mode_to_to_a_method(enum iterator_mode mode) {
   }
 }
 
+/* Returns all rows from the associated query's result set according to the
+ * iteration mode, i.e. as a hash, an array or a single value.
+ * 
+ * @return [Array] array of query result set rows
+ */
 VALUE Iterator_to_a(VALUE self) {
   Iterator_t *iterator = value_to_iterator(self);
   to_a_method method = mode_to_to_a_method(iterator->mode);

--- a/ext/extralite/iterator.c
+++ b/ext/extralite/iterator.c
@@ -105,6 +105,25 @@ VALUE Iterator_next(int argc, VALUE *argv, VALUE self) {
   return rb_block_given_p() ? self : result;
 }
 
+typedef VALUE (*to_a_method)(VALUE);
+
+inline to_a_method mode_to_to_a_method(enum iterator_mode mode) {
+  switch (mode) {
+    case ITERATOR_ARY:
+      return Query_to_a_ary;
+    case ITERATOR_SINGLE_COLUMN:
+      return Query_to_a_single_column;
+    default:
+      return Query_to_a_hash;
+  }
+}
+
+VALUE Iterator_to_a(VALUE self) {
+  Iterator_t *iterator = value_to_iterator(self);
+  to_a_method method = mode_to_to_a_method(iterator->mode);
+  return method(iterator->query);
+}
+
 void Init_ExtraliteIterator(void) {
   VALUE mExtralite = rb_define_module("Extralite");
 
@@ -116,6 +135,7 @@ void Init_ExtraliteIterator(void) {
   rb_define_method(cIterator, "initialize", Iterator_initialize, 2);
   rb_define_method(cIterator, "each", Iterator_each, 0);
   rb_define_method(cIterator, "next", Iterator_next, -1);
+  rb_define_method(cIterator, "to_a", Iterator_to_a, 0);
 
   SYM_hash          = ID2SYM(rb_intern("hash"));
   SYM_ary           = ID2SYM(rb_intern("ary"));

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -14,14 +14,14 @@ static size_t Query_size(const void *ptr) {
 }
 
 static void Query_mark(void *ptr) {
-  Query_t *stmt = ptr;
-  rb_gc_mark(stmt->db);
-  rb_gc_mark(stmt->sql);
+  Query_t *query = ptr;
+  rb_gc_mark(query->db);
+  rb_gc_mark(query->sql);
 }
 
 static void Query_free(void *ptr) {
-  Query_t *stmt = ptr;
-  if (stmt->stmt) sqlite3_finalize(stmt->stmt);
+  Query_t *query = ptr;
+  if (query->stmt) sqlite3_finalize(query->stmt);
   free(ptr);
 }
 
@@ -32,54 +32,159 @@ static const rb_data_type_t Query_type = {
 };
 
 static VALUE Query_allocate(VALUE klass) {
-  Query_t *stmt = ALLOC(Query_t);
-  stmt->db = Qnil;
-  stmt->sqlite3_db = NULL;
-  stmt->stmt = NULL;
-  return TypedData_Wrap_Struct(klass, &Query_type, stmt);
+  Query_t *query = ALLOC(Query_t);
+  query->db = Qnil;
+  query->sql = Qnil;
+  query->sqlite3_db = NULL;
+  query->stmt = NULL;
+  return TypedData_Wrap_Struct(klass, &Query_type, query);
 }
 
-#define GetQuery(obj, stmt) \
-  TypedData_Get_Struct((obj), Query_t, &Query_type, (stmt))
+static inline Query_t *value_to_query(VALUE obj) {
+  Query_t *query;
+  TypedData_Get_Struct((obj), Query_t, &Query_type, (query));
+  return query;
+}
 
 /* call-seq: initialize(db, sql)
  *
- * Initializes a new SQLite prepared statement with the given path.
+ * Initializes a new prepared query with the given database and SQL string.
  */
 VALUE Query_initialize(VALUE self, VALUE db, VALUE sql) {
-  Query_t *stmt;
-  GetQuery(self, stmt);
+  Query_t *query = value_to_query(self);
 
   sql = rb_funcall(sql, ID_strip, 0);
   if (!RSTRING_LEN(sql))
     rb_raise(cError, "Cannot prepare an empty SQL query");
 
-  stmt->db = db;
-  stmt->db_struct = Database_struct(db);
-  stmt->sqlite3_db = Database_sqlite3_db(db);
-  stmt->sql = sql;
-  stmt->stmt = 0L;
-  stmt->closed = 0;
+  query->db = db;
+  query->db_struct = Database_struct(db);
+  query->sqlite3_db = Database_sqlite3_db(db);
+  query->sql = sql;
+  query->stmt = NULL;
+  query->closed = 0;
+  query->eof = 0;
 
   return Qnil;
 }
 
+void query_reset_and_bind(Query_t *query, int argc, VALUE * argv) {
+  if (!query->stmt)
+    prepare_single_stmt(query->sqlite3_db, &query->stmt, query->sql);
+  sqlite3_reset(query->stmt);
+  query->eof = 0;
+  if (argc > 0) {
+    sqlite3_clear_bindings(query->stmt);
+    bind_all_parameters(query->stmt, argc, argv);
+  }
+}
+
+VALUE Query_reset(int argc, VALUE *argv, VALUE self) {
+  Query_t *query = value_to_query(self);
+  if (query->closed) rb_raise(cError, "Query is closed");
+
+  query_reset_and_bind(query, argc, argv);
+  return self;
+}
+
+#define MAX_ROWS(max_rows) (max_rows == SINGLE_ROW ? 1 : max_rows)
+
+static inline VALUE Query_perform_next(VALUE self, int max_rows, VALUE (*call)(query_ctx *)) {
+  Query_t *query = value_to_query(self);
+  if (query->closed) rb_raise(cError, "Query is closed");
+  
+  if (!query->stmt) query_reset_and_bind(query, 0, NULL);
+  if (query->eof) return rb_block_given_p() ? self : Qnil;
+
+  if (query->db_struct->trace_block != Qnil)
+    rb_funcall(query->db_struct->trace_block, ID_call, 1, query->sql);
+
+  query_ctx ctx = {
+    self,
+    query->sqlite3_db,
+    query->stmt,
+    Qnil,
+    QUERY_MODE(max_rows == SINGLE_ROW ? QUERY_SINGLE_ROW : QUERY_MULTI_ROW),
+    MAX_ROWS(max_rows),
+    0
+  };
+  VALUE result = call(&ctx);
+  query->eof = ctx.eof;
+  return (ctx.mode == QUERY_YIELD) ? self : result;
+}
+
+#define MAX_ROWS_FROM_ARGV(argc, argv) (argc == 1 ? FIX2INT(argv[0]) : SINGLE_ROW)
+
+VALUE Query_next_hash(int argc, VALUE *argv, VALUE self) {
+  rb_check_arity(argc, 0, 1);
+  return Query_perform_next(self, MAX_ROWS_FROM_ARGV(argc, argv), safe_query_hash);
+}
+
+VALUE Query_next_ary(int argc, VALUE *argv, VALUE self) {
+  rb_check_arity(argc, 0, 1);
+  return Query_perform_next(self, MAX_ROWS_FROM_ARGV(argc, argv), safe_query_ary);
+}
+
+VALUE Query_next_single_column(int argc, VALUE *argv, VALUE self) {
+  rb_check_arity(argc, 0, 1);
+  return Query_perform_next(self, MAX_ROWS_FROM_ARGV(argc, argv), safe_query_single_column);
+}
+
+VALUE Query_to_a_hash(VALUE self) {
+  Query_t *query = value_to_query(self);
+  query_reset_and_bind(query, 0, NULL);
+  return Query_perform_next(self, ALL_ROWS, safe_query_hash);
+}
+
+VALUE Query_to_a_ary(VALUE self) {
+  Query_t *query = value_to_query(self);
+  query_reset_and_bind(query, 0, NULL);
+  return Query_perform_next(self, ALL_ROWS, safe_query_ary);
+}
+
+VALUE Query_to_a_single_column(VALUE self) {
+  Query_t *query = value_to_query(self);
+  query_reset_and_bind(query, 0, NULL);
+  return Query_perform_next(self, ALL_ROWS, safe_query_single_column);
+}
+
+VALUE Query_each_hash(VALUE self) {
+  if (!rb_block_given_p()) return rb_funcall(cIterator, ID_new, 2, self, SYM_hash);
+
+  Query_t *query = value_to_query(self);
+  query_reset_and_bind(query, 0, NULL);
+  return Query_perform_next(self, ALL_ROWS, safe_query_hash);
+}
+
+VALUE Query_each_ary(VALUE self) {
+  if (!rb_block_given_p()) return rb_funcall(cIterator, ID_new, 2, self, SYM_ary);
+
+  Query_t *query = value_to_query(self);
+  query_reset_and_bind(query, 0, NULL);
+  return Query_perform_next(self, ALL_ROWS, safe_query_ary);
+}
+
+VALUE Query_each_single_column(VALUE self) {
+  if (!rb_block_given_p()) return rb_funcall(cIterator, ID_new, 2, self, SYM_single_column);
+
+  Query_t *query = value_to_query(self);
+  query_reset_and_bind(query, 0, NULL);
+  return Query_perform_next(self, ALL_ROWS, safe_query_single_column);
+}
+
 static inline VALUE Query_perform_query(int argc, VALUE *argv, VALUE self, VALUE (*call)(query_ctx *)) {
-  Query_t *stmt;
-  GetQuery(self, stmt);
+  Query_t *query = value_to_query(self);
+  if (query->closed) rb_raise(cError, "Query is closed");
 
-  if (stmt->closed)
-    rb_raise(cError, "Prepared statement is closed");
+  if (!query->stmt)
+    prepare_single_stmt(query->sqlite3_db, &query->stmt, query->sql);
+  if (query->db_struct->trace_block != Qnil)
+    rb_funcall(query->db_struct->trace_block, ID_call, 1, query->sql);
 
-  if (!stmt->stmt)
-    prepare_single_stmt(stmt->sqlite3_db, &stmt->stmt, stmt->sql);
-  if (stmt->db_struct->trace_block != Qnil)
-    rb_funcall(stmt->db_struct->trace_block, ID_call, 1, stmt->sql);
-
-  sqlite3_reset(stmt->stmt);
-  sqlite3_clear_bindings(stmt->stmt);
-  bind_all_parameters(stmt->stmt, argc, argv);
-  query_ctx ctx = { self, stmt->sqlite3_db, stmt->stmt };
+  sqlite3_reset(query->stmt);
+  sqlite3_clear_bindings(query->stmt);
+  bind_all_parameters(query->stmt, argc, argv);
+  query_ctx ctx = { self, query->sqlite3_db, query->stmt, Qnil, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS };
   return call(&ctx);
 }
 
@@ -224,16 +329,13 @@ VALUE Query_query_single_value(int argc, VALUE *argv, VALUE self) {
  *
  */
 VALUE Query_execute_multi(VALUE self, VALUE params_array) {
-  Query_t *stmt;
-  GetQuery(self, stmt);
+  Query_t *query = value_to_query(self);
+  if (query->closed) rb_raise(cError, "Query is closed");
 
-  if (stmt->closed)
-    rb_raise(cError, "Prepared statement is closed");
+  if (!query->stmt)
+    prepare_single_stmt(query->sqlite3_db, &query->stmt, query->sql);
 
-  if (!stmt->stmt)
-    prepare_single_stmt(stmt->sqlite3_db, &stmt->stmt, stmt->sql);
-
-  query_ctx ctx = { self, stmt->sqlite3_db, stmt->stmt, params_array };
+  query_ctx ctx = { self, query->sqlite3_db, query->stmt, params_array, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS };
   return safe_execute_multi(&ctx);
 }
 
@@ -241,29 +343,27 @@ VALUE Query_execute_multi(VALUE self, VALUE params_array) {
  *   stmt.database -> database
  *   stmt.db -> database
  *
- * Returns the database associated with the prepared statement.
+ * Returns the database associated with the query.
  */
 VALUE Query_database(VALUE self) {
-  Query_t *stmt;
-  GetQuery(self, stmt);
-  return stmt->db;
+  Query_t *query = value_to_query(self);
+  return query->db;
 }
 
 /* call-seq:
  *   stmt.sql -> sql
  *
- * Returns the SQL query used for the prepared statement.
+ * Returns the SQL string for the query.
  */
 VALUE Query_sql(VALUE self) {
-  Query_t *stmt;
-  GetQuery(self, stmt);
-  return stmt->sql;
+  Query_t *query = value_to_query(self);
+  return query->sql;
 }
 
 /* call-seq:
  *   stmt.columns -> columns
  *
- * Returns the column names for the prepared statement without running it.
+ * Returns the column names for the query without running it.
  */
 VALUE Query_columns(VALUE self) {
   return Query_perform_query(0, NULL, self, safe_query_columns);
@@ -272,30 +372,27 @@ VALUE Query_columns(VALUE self) {
 /* call-seq:
  *   stmt.close -> stmt
  *
- * Closes the prepared statement. Running a closed prepared statement will raise
- * an error.
+ * Closes the query. Attempting to run a closed prepared statement will raise an
+ * error.
  */
 VALUE Query_close(VALUE self) {
-  Query_t *stmt;
-  GetQuery(self, stmt);
-  if (stmt->stmt) {
-    sqlite3_finalize(stmt->stmt);
-    stmt->stmt = NULL;
+  Query_t *query = value_to_query(self);
+  if (query->stmt) {
+    sqlite3_finalize(query->stmt);
+    query->stmt = NULL;
   }
-  stmt->closed = 1;
+  query->closed = 1;
   return self;
 }
 
 /* call-seq:
  *   stmt.closed? -> closed
  *
- * Returns true if the prepared statement is closed.
+ * Returns true if the query is closed.
  */
 VALUE Query_closed_p(VALUE self) {
-  Query_t *stmt;
-  GetQuery(self, stmt);
-
-  return stmt->closed ? Qtrue : Qfalse;
+  Query_t *query = value_to_query(self);
+  return query->closed ? Qtrue : Qfalse;
 }
 
 /* call-seq:
@@ -309,16 +406,13 @@ VALUE Query_status(int argc, VALUE* argv, VALUE self) {
 
   rb_scan_args(argc, argv, "11", &op, &reset);
 
-  Query_t *stmt;
-  GetQuery(self, stmt);
+  Query_t *query = value_to_query(self);
+  if (query->closed) rb_raise(cError, "Query is closed");
 
-  if (stmt->closed)
-    rb_raise(cError, "Prepared statement is closed");
+  if (!query->stmt)
+    prepare_single_stmt(query->sqlite3_db, &query->stmt, query->sql);
 
-  if (!stmt->stmt)
-    prepare_single_stmt(stmt->sqlite3_db, &stmt->stmt, stmt->sql);
-
-  int value = sqlite3_stmt_status(stmt->stmt, NUM2INT(op), RTEST(reset) ? 1 : 0);
+  int value = sqlite3_stmt_status(query->stmt, NUM2INT(op), RTEST(reset) ? 1 : 0);
   return INT2NUM(value);
 }
 
@@ -328,6 +422,7 @@ void Init_ExtraliteQuery(void) {
   cQuery = rb_define_class_under(mExtralite, "Query", rb_cObject);
   rb_define_alloc_func(cQuery, Query_allocate);
 
+  rb_define_method(cQuery, "bind", Query_reset, -1);
   rb_define_method(cQuery, "close", Query_close, 0);
   rb_define_method(cQuery, "closed?", Query_closed_p, 0);
   rb_define_method(cQuery, "columns", Query_columns, 0);
@@ -335,12 +430,23 @@ void Init_ExtraliteQuery(void) {
   rb_define_method(cQuery, "db", Query_database, 0);
   rb_define_method(cQuery, "execute_multi", Query_execute_multi, 1);
   rb_define_method(cQuery, "initialize", Query_initialize, 2);
-  rb_define_method(cQuery, "query", Query_query_hash, -1);
-  rb_define_method(cQuery, "query_hash", Query_query_hash, -1);
-  rb_define_method(cQuery, "query_ary", Query_query_ary, -1);
-  rb_define_method(cQuery, "query_single_row", Query_query_single_row, -1);
-  rb_define_method(cQuery, "query_single_column", Query_query_single_column, -1);
-  rb_define_method(cQuery, "query_single_value", Query_query_single_value, -1);
+
+  rb_define_method(cQuery, "each", Query_each_hash, 0);
+  rb_define_method(cQuery, "each_ary", Query_each_ary, 0);
+  rb_define_method(cQuery, "each_hash", Query_each_hash, 0);
+  rb_define_method(cQuery, "each_single_column", Query_each_single_column, 0);
+
+  rb_define_method(cQuery, "next", Query_next_hash, -1);
+  rb_define_method(cQuery, "next_ary", Query_next_ary, -1);
+  rb_define_method(cQuery, "next_hash", Query_next_hash, -1);
+  rb_define_method(cQuery, "next_single_column", Query_next_single_column, -1);
+
+  rb_define_method(cQuery, "to_a", Query_to_a_hash, 0);
+  rb_define_method(cQuery, "to_a_ary", Query_to_a_ary, 0);
+  rb_define_method(cQuery, "to_a_hash", Query_to_a_hash, 0);
+  rb_define_method(cQuery, "to_a_single_column", Query_to_a_single_column, 0);
+
+  rb_define_method(cQuery, "reset", Query_reset, -1);
   rb_define_method(cQuery, "sql", Query_sql, 0);
   rb_define_method(cQuery, "status", Query_status, -1);
 }

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -97,6 +97,13 @@ VALUE Query_reset(int argc, VALUE *argv, VALUE self) {
   return self;
 }
 
+VALUE Query_eof_p(VALUE self) {
+  Query_t *query = value_to_query(self);
+  if (query->closed) rb_raise(cError, "Query is closed");
+
+  return query->eof ? Qtrue : Qfalse;
+}
+
 #define MAX_ROWS(max_rows) (max_rows == SINGLE_ROW ? 1 : max_rows)
 
 static inline VALUE Query_perform_next(VALUE self, int max_rows, VALUE (*call)(query_ctx *)) {
@@ -310,6 +317,7 @@ void Init_ExtraliteQuery(void) {
   rb_define_method(cQuery, "columns", Query_columns, 0);
   rb_define_method(cQuery, "database", Query_database, 0);
   rb_define_method(cQuery, "db", Query_database, 0);
+  rb_define_method(cQuery, "eof?", Query_eof_p, 0);
   rb_define_method(cQuery, "execute_multi", Query_execute_multi, 1);
   rb_define_method(cQuery, "initialize", Query_initialize, 2);
 

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -4,7 +4,9 @@
 /*
  * Document-class: Extralite::Query
  *
- * This class represents a prepared statement.
+ * This class represents a prepared query that can be reused with different
+ * parameters. It encapsulates [SQLite prepared
+ * statements](https://sqlite.org/c3ref/stmt.html).
  */
 
 VALUE cQuery;
@@ -46,9 +48,14 @@ static inline Query_t *value_to_query(VALUE obj) {
   return query;
 }
 
-/* call-seq: initialize(db, sql)
+/* Initializes a new prepared query with the given database and SQL string. A
+ * `Query` is normally instantiated by calling `Database#prepare`:
  *
- * Initializes a new prepared query with the given database and SQL string.
+ *     query = @db.prepare('select * from foo')
+ *
+ * @param db [Extralite::Database] associated database
+ * @param sql [String] SQL string
+ * @return [void]
  */
 VALUE Query_initialize(VALUE self, VALUE db, VALUE sql) {
   Query_t *query = value_to_query(self);
@@ -68,6 +75,34 @@ VALUE Query_initialize(VALUE self, VALUE db, VALUE sql) {
   return Qnil;
 }
 
+/* Resets the underlying prepared statement. After calling this method the
+ * underlying prepared statement is reset to its initial state, and any call to
+ * one of the `#next_xxx` methods will return the first row in the query's
+ * result set.
+ *
+ *     query = @db.prepare('select * from foo where bar = ?')
+ *     first = query.next
+ *     second = query.next
+ *     query.reset
+ *     query.next #=> returns the first row again
+ *
+ * @return [Extralite::Query] self
+ */
+VALUE Query_reset(VALUE self) {
+  Query_t *query = value_to_query(self);
+  if (query->closed) rb_raise(cError, "Query is closed");
+
+  if (!query->stmt)
+    prepare_single_stmt(query->sqlite3_db, &query->stmt, query->sql);
+
+  if (query->db_struct->trace_block != Qnil)
+    rb_funcall(query->db_struct->trace_block, ID_call, 1, query->sql);
+
+  sqlite3_reset(query->stmt);
+  query->eof = 0;
+  return self;
+}
+
 void query_reset_and_bind(Query_t *query, int argc, VALUE * argv) {
   if (!query->stmt)
     prepare_single_stmt(query->sqlite3_db, &query->stmt, query->sql);
@@ -83,13 +118,28 @@ void query_reset_and_bind(Query_t *query, int argc, VALUE * argv) {
   }
 }
 
-/* call-seq:
- *    query.reset(*parameters) -> query
- *    query.bind(*parameters) -> query
+/* Resets the underlying prepared statement and rebinds parameters if any are
+ * given. After calling this method the underlying prepared statement is reset
+ * to its initial state, and any call to one of the `#next_xxx` methods will
+ * return the first row in the query's result set.
  *
- * Resets the underlying prepared statement and rebinds the given parameters.
+ * Bound parameters can be specified as a list of values or as a hash mapping
+ * parameter names to values. When parameters are given as a splatted array, the
+ * query should specify parameters using `?`:
+ * 
+ *     query = db.prepare('select * from foo where x = ?')
+ *     query.bind(42)
+ *
+ * Named placeholders are specified using `:`. The placeholder values are
+ * specified using a hash, where keys are either strings are symbols. String
+ * keys can include or omit the `:` prefix. The following are equivalent:
+ * 
+ *     query = db.prepare('select * from foo where x = :bar')
+ *     query.bind(bar: 42)
+ *
+ * @return [Extralite::Query] self
  */
-VALUE Query_reset(int argc, VALUE *argv, VALUE self) {
+VALUE Query_bind(int argc, VALUE *argv, VALUE self) {
   Query_t *query = value_to_query(self);
   if (query->closed) rb_raise(cError, "Query is closed");
 
@@ -97,6 +147,10 @@ VALUE Query_reset(int argc, VALUE *argv, VALUE self) {
   return self;
 }
 
+/* Returns true if iteration has reached the end of the result set.
+ *
+ * @return [boolean] true if iteration has reached the end of the result set
+ */
 VALUE Query_eof_p(VALUE self) {
   Query_t *query = value_to_query(self);
   if (query->closed) rb_raise(cError, "Query is closed");
@@ -129,39 +183,115 @@ static inline VALUE Query_perform_next(VALUE self, int max_rows, VALUE (*call)(q
 
 #define MAX_ROWS_FROM_ARGV(argc, argv) (argc == 1 ? FIX2INT(argv[0]) : SINGLE_ROW)
 
+/* Returns the next 1 or more rows from the associated query's result set as a
+ * hash.
+ * 
+ * If no row count is given, a single row is returned. If a row count is given,
+ * an array containing up to the `row_count` rows is returned. If `row_count` is
+ * -1, all rows are returned. If the end of the result set has been reached,
+ * `nil` is returned.
+ * 
+ * If a block is given, rows are passed to the block and self is returned.
+ *
+ * @overload next()
+ *   @return [Hash, Extralite::Query] next row or self if block is given
+ * @overload next_hash()
+ *   @return [Hash, Extralite::Query] next row or self if block is given
+ * @overload next(row_count)
+ *   @param row_count [Integer] maximum row count or -1 for all rows
+ *   @return [Array<Hash>, Extralite::Query] next rows or self if block is given
+ * @overload next_hash(row_count)
+ *   @param row_count [Integer] maximum row count or -1 for all rows
+ *   @return [Array<Hash>, Extralite::Query] next rows or self if block is given
+ */
 VALUE Query_next_hash(int argc, VALUE *argv, VALUE self) {
   rb_check_arity(argc, 0, 1);
   return Query_perform_next(self, MAX_ROWS_FROM_ARGV(argc, argv), safe_query_hash);
 }
 
+/* Returns the next 1 or more rows from the associated query's result set as an
+ * array.
+ * 
+ * If no row count is given, a single row is returned. If a row count is given,
+ * an array containing up to the `row_count` rows is returned. If `row_count` is
+ * -1, all rows are returned. If the end of the result set has been reached,
+ * `nil` is returned.
+ * 
+ * If a block is given, rows are passed to the block and self is returned.
+ *
+ * @overload next_ary()
+ *   @return [Array, Extralite::Query] next row or self if block is given
+ * @overload next_ary(row_count)
+ *   @param row_count [Integer] maximum row count or -1 for all rows
+ *   @return [Array<Array>, Extralite::Query] next rows or self if block is given
+ */
 VALUE Query_next_ary(int argc, VALUE *argv, VALUE self) {
   rb_check_arity(argc, 0, 1);
   return Query_perform_next(self, MAX_ROWS_FROM_ARGV(argc, argv), safe_query_ary);
 }
 
+/* Returns the next 1 or more rows from the associated query's result set as an
+ * single values. If the result set contains more than one column an error is
+ * raised.
+ * 
+ * If no row count is given, a single row is returned. If a row count is given,
+ * an array containing up to the `row_count` rows is returned. If `row_count` is
+ * -1, all rows are returned. If the end of the result set has been reached,
+ * `nil` is returned.
+ * 
+ * If a block is given, rows are passed to the block and self is returned.
+ *
+ * @overload next_ary()
+ *   @return [Object, Extralite::Query] next row or self if block is given
+ * @overload next_ary(row_count)
+ *   @param row_count [Integer] maximum row count or -1 for all rows
+ *   @return [Array<Object>, Extralite::Query] next rows or self if block is given
+ */
 VALUE Query_next_single_column(int argc, VALUE *argv, VALUE self) {
   rb_check_arity(argc, 0, 1);
   return Query_perform_next(self, MAX_ROWS_FROM_ARGV(argc, argv), safe_query_single_column);
 }
 
+/* Returns all rows in the associated query's result set as hashes.
+ * 
+ * @overload to_a()
+ *   @return [Array<Hash>] all rows
+ * @overload to_a_hash
+ *   @return [Array<Hash>] all rows
+ */
 VALUE Query_to_a_hash(VALUE self) {
   Query_t *query = value_to_query(self);
   query_reset_and_bind(query, 0, NULL);
   return Query_perform_next(self, ALL_ROWS, safe_query_hash);
 }
 
+/* Returns all rows in the associated query's result set as arrays.
+ * 
+ * @return [Array<Array>] all rows
+ */
 VALUE Query_to_a_ary(VALUE self) {
   Query_t *query = value_to_query(self);
   query_reset_and_bind(query, 0, NULL);
   return Query_perform_next(self, ALL_ROWS, safe_query_ary);
 }
 
+/* Returns all rows in the associated query's result set as single values. If
+ * the result set contains more than one column an error is raised.
+ * 
+ * @return [Array<Object>] all rows
+ */
 VALUE Query_to_a_single_column(VALUE self) {
   Query_t *query = value_to_query(self);
   query_reset_and_bind(query, 0, NULL);
   return Query_perform_next(self, ALL_ROWS, safe_query_single_column);
 }
 
+/* Iterates through the result set, passing each row to the given block as a
+ * hash. If no block is given, returns a `Extralite::Iterator` instance in hash
+ * mode.
+ * 
+ * @return [Extralite::Query, Extralite::Iterator] self or an iterator if no block is given
+ */
 VALUE Query_each_hash(VALUE self) {
   if (!rb_block_given_p()) return rb_funcall(cIterator, ID_new, 2, self, SYM_hash);
 
@@ -170,6 +300,12 @@ VALUE Query_each_hash(VALUE self) {
   return Query_perform_next(self, ALL_ROWS, safe_query_hash);
 }
 
+/* Iterates through the result set, passing each row to the given block as an
+ * array. If no block is given, returns a `Extralite::Iterator` instance in
+ * array mode.
+ * 
+ * @return [Extralite::Query, Extralite::Iterator] self or an iterator if no block is given
+ */
 VALUE Query_each_ary(VALUE self) {
   if (!rb_block_given_p()) return rb_funcall(cIterator, ID_new, 2, self, SYM_ary);
 
@@ -178,6 +314,13 @@ VALUE Query_each_ary(VALUE self) {
   return Query_perform_next(self, ALL_ROWS, safe_query_ary);
 }
 
+/* Iterates through the result set, passing each row to the given block as a
+ * single value. If the result set contains more than one column an error is
+ * raised. If no block is given, returns a `Extralite::Iterator` instance in
+ * single column mode.
+ * 
+ * @return [Extralite::Query, Extralite::Iterator] self or an iterator if no block is given
+ */
 VALUE Query_each_single_column(VALUE self) {
   if (!rb_block_given_p()) return rb_funcall(cIterator, ID_new, 2, self, SYM_single_column);
 
@@ -202,67 +345,64 @@ static inline VALUE Query_perform_query(int argc, VALUE *argv, VALUE self, VALUE
   return call(&ctx);
 }
 
-/* call-seq:
- *   stmt.execute_multi(params_array) -> changes
+/* Executes the query for each set of parameters in the given array. Parameters
+ * can be specified as either an array (for unnamed parameters) or a hash (for
+ * named parameters). Returns the number of changes effected. This method is
+ * designed for inserting multiple records.
  *
- * Executes the prepared statment for each list of parameters in params_array.
- * Returns the number of changes effected. This method is designed for inserting
- * multiple records.
- *
- *     stmt = db.prepare('insert into foo values (?, ?, ?)')
+ *     query = db.prepare('insert into foo values (?, ?, ?)')
  *     records = [
  *       [1, 2, 3],
  *       [4, 5, 6]
  *     ]
- *     stmt.execute_multi_query(records)
+ *     query.execute_multi(records)
  *
+ * @param parameters [Array<Array, Hash>] array of parameters to run query with
+ * @return [Integer] number of changes effected
  */
-VALUE Query_execute_multi(VALUE self, VALUE params_array) {
+VALUE Query_execute_multi(VALUE self, VALUE parameters) {
   Query_t *query = value_to_query(self);
   if (query->closed) rb_raise(cError, "Query is closed");
 
   if (!query->stmt)
     prepare_single_stmt(query->sqlite3_db, &query->stmt, query->sql);
 
-  query_ctx ctx = { self, query->sqlite3_db, query->stmt, params_array, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS };
+  query_ctx ctx = { self, query->sqlite3_db, query->stmt, parameters, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS };
   return safe_execute_multi(&ctx);
 }
 
-/* call-seq:
- *   stmt.database -> database
- *   stmt.db -> database
+/* Returns the database associated with the query.
  *
- * Returns the database associated with the query.
+ * @overload database()
+ *   @return [Extralite::Database] associated database
+ * @overload db()
+ *   @return [Extralite::Database] associated database
  */
 VALUE Query_database(VALUE self) {
   Query_t *query = value_to_query(self);
   return query->db;
 }
 
-/* call-seq:
- *   stmt.sql -> sql
- *
- * Returns the SQL string for the query.
+/* Returns the SQL string for the query.
+ * 
+ * @return [String] SQL string
  */
 VALUE Query_sql(VALUE self) {
   Query_t *query = value_to_query(self);
   return query->sql;
 }
 
-/* call-seq:
- *   stmt.columns -> columns
- *
- * Returns the column names for the query without running it.
+/* Returns the column names for the query without running it.
+ * 
+ * @return [Array<Symbol>] column names
  */
 VALUE Query_columns(VALUE self) {
   return Query_perform_query(0, NULL, self, safe_query_columns);
 }
 
-/* call-seq:
- *   stmt.close -> stmt
- *
- * Closes the query. Attempting to run a closed prepared statement will raise an
- * error.
+/* Closes the query. Attempting to run a closed query will raise an error.
+ * 
+ * @return [Extralite::Query] self
  */
 VALUE Query_close(VALUE self) {
   Query_t *query = value_to_query(self);
@@ -274,21 +414,26 @@ VALUE Query_close(VALUE self) {
   return self;
 }
 
-/* call-seq:
- *   stmt.closed? -> closed
- *
- * Returns true if the query is closed.
+/* Returns true if the query is closed.
+ * 
+ * @return [boolean] true if query is closed
  */
 VALUE Query_closed_p(VALUE self) {
   Query_t *query = value_to_query(self);
   return query->closed ? Qtrue : Qfalse;
 }
 
-/* call-seq:
- *   stmt.status(op[, reset]) -> value
- *
- * Returns the current status value for the given op. To reset the value, pass
- * true as reset.
+/* Returns the current [status
+ * value](https://sqlite.org/c3ref/c_stmtstatus_counter.html) for the given op.
+ * To reset the value, pass true as reset.
+ * 
+ * @overload status(op)
+ *   @param op [Integer] status op
+ *   @return [Integer] current status value for the given op
+ * @overload status(op, reset)
+ *   @param op [Integer] status op
+ *   @param reset [true] reset flag
+ *   @return [Integer] current status value for the given op (before reset)
  */
 VALUE Query_status(int argc, VALUE* argv, VALUE self) {
   VALUE op, reset;
@@ -311,32 +456,33 @@ void Init_ExtraliteQuery(void) {
   cQuery = rb_define_class_under(mExtralite, "Query", rb_cObject);
   rb_define_alloc_func(cQuery, Query_allocate);
 
-  rb_define_method(cQuery, "bind", Query_reset, -1);
+  rb_define_method(cQuery, "bind", Query_bind, -1);
   rb_define_method(cQuery, "close", Query_close, 0);
   rb_define_method(cQuery, "closed?", Query_closed_p, 0);
   rb_define_method(cQuery, "columns", Query_columns, 0);
   rb_define_method(cQuery, "database", Query_database, 0);
   rb_define_method(cQuery, "db", Query_database, 0);
-  rb_define_method(cQuery, "eof?", Query_eof_p, 0);
-  rb_define_method(cQuery, "execute_multi", Query_execute_multi, 1);
-  rb_define_method(cQuery, "initialize", Query_initialize, 2);
 
   rb_define_method(cQuery, "each", Query_each_hash, 0);
   rb_define_method(cQuery, "each_ary", Query_each_ary, 0);
   rb_define_method(cQuery, "each_hash", Query_each_hash, 0);
   rb_define_method(cQuery, "each_single_column", Query_each_single_column, 0);
 
+  rb_define_method(cQuery, "eof?", Query_eof_p, 0);
+  rb_define_method(cQuery, "execute_multi", Query_execute_multi, 1);
+  rb_define_method(cQuery, "initialize", Query_initialize, 2);
+
   rb_define_method(cQuery, "next", Query_next_hash, -1);
   rb_define_method(cQuery, "next_ary", Query_next_ary, -1);
   rb_define_method(cQuery, "next_hash", Query_next_hash, -1);
   rb_define_method(cQuery, "next_single_column", Query_next_single_column, -1);
 
+  rb_define_method(cQuery, "reset", Query_reset, 0);
+  rb_define_method(cQuery, "sql", Query_sql, 0);
+  rb_define_method(cQuery, "status", Query_status, -1);
+
   rb_define_method(cQuery, "to_a", Query_to_a_hash, 0);
   rb_define_method(cQuery, "to_a_ary", Query_to_a_ary, 0);
   rb_define_method(cQuery, "to_a_hash", Query_to_a_hash, 0);
   rb_define_method(cQuery, "to_a_single_column", Query_to_a_single_column, 0);
-
-  rb_define_method(cQuery, "reset", Query_reset, -1);
-  rb_define_method(cQuery, "sql", Query_sql, 0);
-  rb_define_method(cQuery, "status", Query_status, -1);
 }

--- a/lib/sequel/adapters/extralite.rb
+++ b/lib/sequel/adapters/extralite.rb
@@ -281,9 +281,9 @@ module Sequel
           log_sql << ")"
         end
         if block
-          log_connection_yield(log_sql, conn, args){cps.query(ps_args, &block)}
+          log_connection_yield(log_sql, conn, args){cps.bind(ps_args).each(&block)}
         else
-          log_connection_yield(log_sql, conn, args){cps.query(ps_args){|r|}}
+          log_connection_yield(log_sql, conn, args){cps.bind(ps_args).each {|r|}}
           case type
           when :insert
             conn.last_insert_rowid

--- a/lib/sequel/adapters/extralite.rb
+++ b/lib/sequel/adapters/extralite.rb
@@ -123,14 +123,7 @@ module Sequel
       def connect(server)
         opts = server_opts(server)
         opts[:database] = ':memory:' if blank_object?(opts[:database])
-        # sqlite3_opts = {}
-        # sqlite3_opts[:readonly] = typecast_value_boolean(opts[:readonly]) if opts.has_key?(:readonly)
-        db = ::Extralite::Database.new(opts[:database].to_s)#, sqlite3_opts)
-        # db.busy_timeout(typecast_value_integer(opts.fetch(:timeout, 5000)))
-
-        # if USE_EXTENDED_RESULT_CODES
-        #   db.extended_result_codes = true
-        # end
+        db = ::Extralite::Database.new(opts[:database].to_s)
 
         connection_pragmas.each{|s| log_connection_yield(s, db){db.query(s)}}
 
@@ -163,7 +156,7 @@ module Sequel
       # table while a prepared statement that references it still exists.
       def execute_ddl(sql, opts=OPTS)
         synchronize(opts[:server]) do |conn|
-          conn.prepared_statements.values.each{|cps, s| cps.close}
+          conn.prepared_statements.values.each {|cps, s| cps.close }
           conn.prepared_statements.clear
           super
         end
@@ -347,27 +340,6 @@ module Sequel
       # @!visibility private
       def fetch_rows(sql, &block)
         execute(sql, &block)
-        # execute(sql) do |result|
-        #   cps = db.conversion_procs
-        #   type_procs = result.types.map{|t| cps[base_type_name(t)]}
-        #   j = -1
-        #   cols = result.columns.map{|c| [output_identifier(c), type_procs[(j+=1)]]}
-        #   self.columns = cols.map(&:first)
-        #   max = cols.length
-        #   result.each do |values|
-        #     row = {}
-        #     i = -1
-        #     while (i += 1) < max
-        #       name, type_proc = cols[i]
-        #       v = values[i]
-        #       if type_proc && v
-        #         v = type_proc.call(v)
-        #       end
-        #       row[name] = v
-        #     end
-        #     yield row
-        #   end
-        # end
       end
 
       private

--- a/test/perf_prepared.rb
+++ b/test/perf_prepared.rb
@@ -39,9 +39,9 @@ def extralite_prepare
   db.prepare('select * from foo')
 end
 
-def extralite_run(stmt, count)
+def extralite_run(query, count)
   # db = Extralite::Database.new(DB_PATH)
-  results = stmt.query
+  results = query.to_a
   raise unless results.size == count
 end
 

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -357,8 +357,8 @@ end
 
 
   def test_close_with_open_prepared_statement
-    stmt = @db.prepare('select * from t')
-    stmt.query
+    query = @db.prepare('select * from t')
+    query.next
     @db.close
   end
 end
@@ -439,15 +439,15 @@ class ScenarioTest < MiniTest::Test
     @db.query('select 2')
     assert_equal ['select 1', 'select 2'], sqls
 
-    stmt = @db.prepare('select 3')
+    query = @db.prepare('select 3')
 
-    stmt.query
+    query.to_a
     assert_equal ['select 1', 'select 2', 'select 3'], sqls
 
     # turn off
     @db.trace
 
-    stmt.query
+    query.to_a
 
     @db.query('select 4')
     assert_equal ['select 1', 'select 2', 'select 3'], sqls

--- a/test/test_iterator.rb
+++ b/test/test_iterator.rb
@@ -58,6 +58,20 @@ class IteratorTest < MiniTest::Test
     assert_equal({x: 7, y: 8, z: 9}, iter.next)
     assert_nil iter.next
     assert_nil iter.next
+
+    iter = @query.reset.each_ary
+    assert_equal([1, 2, 3], iter.next)
+    assert_equal([4, 5, 6], iter.next)
+    assert_equal([7, 8, 9], iter.next)
+    assert_nil iter.next
+    assert_nil iter.next
+
+    iter = @db.prepare('select y from t').each_single_column
+    assert_equal(2, iter.next)
+    assert_equal(5, iter.next)
+    assert_equal(8, iter.next)
+    assert_nil iter.next
+    assert_nil iter.next
   end
 
   def test_iterator_enumerable_methods

--- a/test/test_iterator.rb
+++ b/test/test_iterator.rb
@@ -74,6 +74,17 @@ class IteratorTest < MiniTest::Test
     assert_nil iter.next
   end
 
+  def test_iterator_to_a
+    iter = @query.each
+    assert_equal [{x: 1, y: 2, z: 3},{ x: 4, y: 5, z: 6 }, { x: 7, y: 8, z: 9 }], iter.to_a
+
+    iter = @query.each_ary
+    assert_equal [[1, 2, 3], [4, 5, 6], [7, 8, 9]], iter.to_a
+
+    iter = @db.prepare('select x from t').each_single_column
+    assert_equal [1, 4, 7], iter.to_a
+  end
+
   def test_iterator_enumerable_methods
     mapped = @query.each.map { |row| row[:x] * 10 }
     assert_equal [10, 40, 70], mapped

--- a/test/test_iterator.rb
+++ b/test/test_iterator.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+class IteratorTest < MiniTest::Test
+  def setup
+    @db = Extralite::Database.new(':memory:')
+    @db.query('create table if not exists t (x,y,z)')
+    @db.query('delete from t')
+    @db.query('insert into t values (1, 2, 3)')
+    @db.query('insert into t values (4, 5, 6)')
+    @db.query('insert into t values (7, 8, 9)')
+
+    @query = @db.prepare('select * from t')
+  end
+
+  def test_iterator_each_idempotency
+    iter = @query.each
+    assert_equal iter, iter.each
+    assert_equal iter, iter.each.each
+  end
+
+  def test_iterator_hash
+    iter = @query.each
+    assert_kind_of Extralite::Iterator, iter
+
+    buf = []
+    v = iter.each { |r| buf << r }
+    assert_equal iter, v
+    assert_equal [{x: 1, y: 2, z: 3},{ x: 4, y: 5, z: 6 }, { x: 7, y: 8, z: 9 }], buf
+  end
+
+  def test_iterator_ary
+    iter = @query.each_ary
+    assert_kind_of Extralite::Iterator, iter
+
+    buf = []
+    v = iter.each { |r| buf << r }
+    assert_equal iter, v
+    assert_equal [[1, 2, 3], [4, 5, 6], [7, 8, 9]], buf
+  end
+
+  def test_iterator_single_column
+    query = @db.prepare('select x from t')
+    iter = query.each_single_column
+    assert_kind_of Extralite::Iterator, iter
+
+    buf = []
+    v = iter.each { |r| buf << r }
+    assert_equal iter, v
+    assert_equal [1, 4, 7], buf
+  end
+
+  def test_iterator_next
+    iter = @query.each
+    assert_equal({x: 1, y: 2, z: 3}, iter.next)
+    assert_equal({x: 4, y: 5, z: 6}, iter.next)
+    assert_equal({x: 7, y: 8, z: 9}, iter.next)
+    assert_nil iter.next
+    assert_nil iter.next
+  end
+
+  def test_iterator_enumerable_methods
+    mapped = @query.each.map { |row| row[:x] * 10 }
+    assert_equal [10, 40, 70], mapped
+
+    mapped = @query.each_ary.map { |row| row[1] * 10 }
+    assert_equal [20, 50, 80], mapped
+
+    query = @db.prepare('select z from t')
+    mapped = query.each_single_column.map { |v| v * 10 }
+    assert_equal [30, 60, 90], mapped
+  end
+end

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -457,4 +457,30 @@ class QueryTest < MiniTest::Test
     @db.close
     assert_equal [{ x: 4, y: 5, z: 6}], @query.bind(4).to_a
   end
+
+  def test_query_eof
+    query = @db.prepare('select x from t')
+    assert_equal false, query.eof?
+
+    query.next
+    assert_equal false, query.eof?
+
+    query.next(2)
+    assert_equal false, query.eof?
+
+    query.next
+    assert_equal true, query.eof?
+
+    query.next
+    assert_equal true, query.eof?
+
+    query.reset
+    assert_equal false, query.eof?
+
+    query.next
+    assert_equal false, query.eof?
+
+    assert_equal [1, 4, 7], query.to_a_single_column
+    assert_equal true, query.eof?
+  end
 end

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -324,57 +324,16 @@ class QueryTest < MiniTest::Test
   end
 
   def test_query_with_invalid_sql
-    assert_raises(Extralite::SQLError) { @db.prepare('blah').query }
+    assert_raises(Extralite::SQLError) { @db.prepare('blah').to_a }
   end
 
   def test_query_with_multiple_queries
     assert_raises(Extralite::Error) { @db.prepare('select 1; select 2').to_a }
   end
 
-  def test_query_query_hash
-    r = @query.query_hash(4)
-    assert_equal [{x: 4, y: 5, z: 6}], r
-
-    r = @query.query_hash(5)
-    assert_equal [], r
-  end
-
-  def test_query_query_ary
-    r = @query.query_ary(1)
-    assert_equal [[1, 2, 3]], r
-
-    r = @query.query_ary(2)
-    assert_equal [], r
-  end
-
-  def test_query_query_single_row
-    r = @query.query_single_row(4)
-    assert_equal({ x: 4, y: 5, z: 6 }, r)
-
-    r = @query.query_single_row(5)
-    assert_nil r
-  end
-
-  def test_query_query_single_column
-    query = 
-    r = @db.prepare('select y from t').query_single_column
-    assert_equal [2, 5, 8], r
-
-    r = @db.prepare('select y from t where x = 2').query_single_column
-    assert_equal [], r
-end
-
-  def test_query_query_single_value
-    r = @db.prepare('select z from t order by Z desc limit 1').query_single_value
-    assert_equal 9, r
-
-    r = @db.prepare('select z from t where x = 2').query_single_value
-    assert_nil r
-  end
-
   def test_query_multiple_statements
     assert_raises(Extralite::Error) {
-      @db.prepare("insert into t values ('a', 'b', 'c'); insert into t values ('d', 'e', 'f');").query
+      @db.prepare("insert into t values ('a', 'b', 'c'); insert into t values ('d', 'e', 'f');").to_a
     }
   end
 
@@ -382,7 +341,7 @@ end
     error = nil
     begin
       query =@db.prepare("insert into t values foo; insert into t values ('d', 'e', 'f');")
-      query.query
+      query.next
     rescue => error
     end
 
@@ -391,70 +350,49 @@ end
   end
 
   def test_query_repeated_execution_missing_param
-    r = @query.query_hash(4)
-    assert_equal [{x: 4, y: 5, z: 6}], r
+    assert_nil @query.next
 
-    r = @query.query_hash
-    assert_equal [], r
+    @query.bind(4)
+    assert_equal({x: 4, y: 5, z: 6}, @query.next)
   end
 
   def test_query_empty_sql
     assert_raises(Extralite::Error) { @db.prepare(' ') }
 
-    r = @db.prepare('select 1 as foo;  ').query
-    assert_equal [{ foo: 1 }], r
+    r = @db.prepare('select 1 as foo;  ').next
+    assert_equal({ foo: 1 }, r)
   end
 
   def test_query_parameter_binding_simple
-    r = @db.prepare('select x, y, z from t where x = ?').query(1)
-    assert_equal [{ x: 1, y: 2, z: 3 }], r
-
-    r = @db.prepare('select x, y, z from t where z = ?').query(6)
-    assert_equal [{ x: 4, y: 5, z: 6 }], r
+    r = @db.prepare('select x, y, z from t where x = ?').bind(1).next
+    assert_equal({ x: 1, y: 2, z: 3 }, r)
   end
 
   def test_query_parameter_binding_with_index
-    r = @db.prepare('select x, y, z from t where x = ?2').query(0, 1)
-    assert_equal [{ x: 1, y: 2, z: 3 }], r
+    r = @db.prepare('select x, y, z from t where x = ?2').bind(0, 1).next
+    assert_equal({ x: 1, y: 2, z: 3 }, r)
 
-    r = @db.prepare('select x, y, z from t where z = ?3').query(3, 4, 6)
-    assert_equal [{ x: 4, y: 5, z: 6 }], r
+    r = @db.prepare('select x, y, z from t where z = ?3').bind(3, 4, 6).next
+    assert_equal({ x: 4, y: 5, z: 6 }, r)
   end
 
   def test_query_parameter_binding_with_name
-    r = @db.prepare('select x, y, z from t where x = :x').query(x: 1, y: 2)
-    assert_equal [{ x: 1, y: 2, z: 3 }], r
+    r = @db.prepare('select x, y, z from t where x = :x').bind(x: 1, y: 2).next
+    assert_equal({ x: 1, y: 2, z: 3 }, r)
 
-    r = @db.prepare('select x, y, z from t where z = :zzz').query('zzz' => 6)
-    assert_equal [{ x: 4, y: 5, z: 6 }], r
+    r = @db.prepare('select x, y, z from t where z = :zzz').bind('zzz' => 6).next
+    assert_equal({ x: 4, y: 5, z: 6 }, r)
 
-    r = @db.prepare('select x, y, z from t where z = :bazzz').query(':bazzz' => 6)
-    assert_equal [{ x: 4, y: 5, z: 6 }], r
+    r = @db.prepare('select x, y, z from t where z = :bazzz').bind(':bazzz' => 6).next
+    assert_equal({ x: 4, y: 5, z: 6 }, r)
   end
 
   def test_query_parameter_binding_with_index_key
-    r = @db.prepare('select x, y, z from t where z = ?').query(1 => 3)
-    assert_equal [{ x: 1, y: 2, z: 3 }], r
+    r = @db.prepare('select x, y, z from t where z = ?').bind(1 => 3).next
+    assert_equal({ x: 1, y: 2, z: 3 }, r)
 
-    r = @db.prepare('select x, y, z from t where x = ?2').query(1 => 42, 2 => 4)
-    assert_equal [{ x: 4, y: 5, z: 6 }], r
-  end
-
-  def test_query_value_casting
-    r = @db.prepare("select 'abc'").query_single_value
-    assert_equal 'abc', r
-
-    r = @db.prepare('select 123').query_single_value
-    assert_equal 123, r
-
-    r = @db.prepare('select 12.34').query_single_value
-    assert_equal 12.34, r
-
-    r = @db.prepare('select zeroblob(4)').query_single_value
-    assert_equal "\x00\x00\x00\x00", r
-
-    r = @db.prepare('select null').query_single_value
-    assert_nil r
+    r = @db.prepare('select x, y, z from t where x = ?2').bind(1 => 42, 2 => 4).next
+    assert_equal({ x: 4, y: 5, z: 6 }, r)
   end
 
   def test_query_columns
@@ -473,7 +411,7 @@ end
     p.close
     assert_equal true, p.closed?
 
-    assert_raises(Extralite::Error) { p.query_single_value }
+    assert_raises(Extralite::Error) { p.next }
   end
 
   def test_query_execute_multi
@@ -497,26 +435,26 @@ end
 
   def test_query_status
     assert_equal 0, @query.status(Extralite::SQLITE_STMTSTATUS_RUN)
-    @query.query
+    @query.to_a
     assert_equal 1, @query.status(Extralite::SQLITE_STMTSTATUS_RUN)
-    @query.query
+    @query.to_a
     assert_equal 2, @query.status(Extralite::SQLITE_STMTSTATUS_RUN)
-    @query.query
+    @query.to_a
     assert_equal 3, @query.status(Extralite::SQLITE_STMTSTATUS_RUN, true)
     assert_equal 0, @query.status(Extralite::SQLITE_STMTSTATUS_RUN)
   end
 
   def test_query_status_after_close
     assert_equal 0, @query.status(Extralite::SQLITE_STMTSTATUS_RUN)
-    @query.query
+    @query.to_a
     assert_equal 1, @query.status(Extralite::SQLITE_STMTSTATUS_RUN)
     @query.close
     assert_raises(Extralite::Error) { @query.status(Extralite::SQLITE_STMTSTATUS_RUN) }
   end
 
   def test_query_after_db_close
-    assert_equal [{ x: 4, y: 5, z: 6}], @query.query(4)
+    assert_equal [{ x: 4, y: 5, z: 6}], @query.bind(4).to_a
     @db.close
-    assert_equal [{ x: 4, y: 5, z: 6}], @query.query(4)
+    assert_equal [{ x: 4, y: 5, z: 6}], @query.bind(4).to_a
   end
 end


### PR DESCRIPTION
- Rename PreparedStatement to Query
- Implement external iteration for Query
- Remove Query#query_xxx methods
- Implement Query#eof?
- Add more tests for Iterator#next
- Implement Iterator#to_a
- Add docs for Query and Iterator classes
- Tie up loose ends: docs, Sequel adapter, benchmark
