### PR TITLE
Add support for binding named parameters from Struct and Data classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,18 @@ db.query_single_value("select 'foo'") #=> "foo"
 
 # parameter binding (works for all query_xxx methods)
 db.query_hash('select ? as foo, ? as bar', 1, 2) #=> [{ :foo => 1, :bar => 2 }]
+db.query_hash('select ?2 as foo, ?1 as bar, ?1 * ?2 as baz', 6, 7) #=> [{ :foo => 7, :bar => 6, :baz => 42 }]
 
 # parameter binding of named parameters
 db.query('select * from foo where bar = :bar', bar: 42)
 db.query('select * from foo where bar = :bar', 'bar' => 42)
 db.query('select * from foo where bar = :bar', ':bar' => 42)
+
+# parameter binding of named parameters from Struct and Data
+SomeStruct = Struct.new(:foo, :bar)
+db.query_single_column('select :bar', SomeStruct.new(41, 42)) #=> [42]
+SomeData = Data.define(:foo, :bar)
+db.query_single_column('select :bar', SomeData.new(foo: 41, bar: 42)) #=> [42]
 
 # insert multiple rows
 db.execute_multi('insert into foo values (?)', ['bar', 'baz'])

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -6,6 +6,7 @@ VALUE cError;
 VALUE cSQLError;
 VALUE cBusyError;
 VALUE cInterruptError;
+VALUE cParameterError;
 VALUE eArgumentError;
 
 ID ID_bind;
@@ -791,10 +792,12 @@ void Init_ExtraliteDatabase(void) {
   cSQLError = rb_define_class_under(mExtralite, "SQLError", cError);
   cBusyError = rb_define_class_under(mExtralite, "BusyError", cError);
   cInterruptError = rb_define_class_under(mExtralite, "InterruptError", cError);
+  cParameterError = rb_define_class_under(mExtralite, "ParameterError", cError);
   rb_gc_register_mark_object(cError);
   rb_gc_register_mark_object(cSQLError);
   rb_gc_register_mark_object(cBusyError);
   rb_gc_register_mark_object(cInterruptError);
+  rb_gc_register_mark_object(cParameterError);
 
   eArgumentError = rb_const_get(rb_cObject, rb_intern("ArgumentError"));
 

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -28,6 +28,7 @@ extern VALUE cError;
 extern VALUE cSQLError;
 extern VALUE cBusyError;
 extern VALUE cInterruptError;
+extern VALUE cParameterError;
 
 extern ID ID_call;
 extern ID ID_keys;

--- a/lib/extralite.rb
+++ b/lib/extralite.rb
@@ -25,6 +25,10 @@ module Extralite
   class InterruptError < Error
   end
 
+  # An exception raised when an Extralite doesn't know how to bind a parameter to a query
+  class ParameterError < Error
+  end
+
   # An SQLite database
   class Database
     # @!visibility private


### PR DESCRIPTION
It reuses the binding logic for hash keys. Additionally, it improves error message for unsupported values and key types in hashes.