### PR TITLE
Remove redundant method calls

### DIFF
--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -799,11 +799,6 @@ void Init_ExtraliteDatabase(void) {
   cBusyError = rb_define_class_under(mExtralite, "BusyError", cError);
   cInterruptError = rb_define_class_under(mExtralite, "InterruptError", cError);
   cParameterError = rb_define_class_under(mExtralite, "ParameterError", cError);
-  rb_gc_register_mark_object(cError);
-  rb_gc_register_mark_object(cSQLError);
-  rb_gc_register_mark_object(cBusyError);
-  rb_gc_register_mark_object(cInterruptError);
-  rb_gc_register_mark_object(cParameterError);
 
   eArgumentError = rb_const_get(rb_cObject, rb_intern("ArgumentError"));
 


### PR DESCRIPTION
`rb_gc_register_mark_object` isn't needed for objects created with `rb_define_class_under`

see https://alanwu.space/post/check-compaction/