### PR TITLE
Implement GVL release threshold

### DIFF
--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -43,6 +43,7 @@ extern VALUE SYM_single_column;
 typedef struct {
   sqlite3 *sqlite3_db;
   VALUE   trace_block;
+  int     gvl_release_threshold;
 } Database_t;
 
 typedef struct {
@@ -80,7 +81,8 @@ typedef struct {
   enum query_mode mode;
   int             max_rows;
   int             eof;
-  int             row_count;
+  int             gvl_release_threshold;
+  int             step_count;
 } query_ctx;
 
 enum gvl_mode {
@@ -92,8 +94,9 @@ enum gvl_mode {
 #define SINGLE_ROW -2
 #define QUERY_MODE(default) (rb_block_given_p() ? QUERY_YIELD : default)
 #define MULTI_ROW_P(mode) (mode == QUERY_MULTI_ROW)
-#define QUERY_CTX(self, sqlite3_db, stmt, params, mode, max_rows) \
-  { self, sqlite3_db, stmt, params, mode, max_rows, 0, 0 }
+#define QUERY_CTX(self, db, stmt, params, mode, max_rows) \
+  { self, db->sqlite3_db, stmt, params, mode, max_rows, 0, db->gvl_release_threshold, 0 }
+#define DEFAULT_GVL_RELEASE_THRESHOLD 1000
 
 extern rb_encoding *UTF8_ENCODING;
 

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -80,12 +80,20 @@ typedef struct {
   enum query_mode mode;
   int             max_rows;
   int             eof;
+  int             row_count;
 } query_ctx;
+
+enum gvl_mode {
+  GVL_RELEASE,
+  GVL_HOLD
+};
 
 #define ALL_ROWS -1
 #define SINGLE_ROW -2
 #define QUERY_MODE(default) (rb_block_given_p() ? QUERY_YIELD : default)
 #define MULTI_ROW_P(mode) (mode == QUERY_MULTI_ROW)
+#define QUERY_CTX(self, sqlite3_db, stmt, params, mode, max_rows) \
+  { self, sqlite3_db, stmt, params, mode, max_rows, 0, 0 }
 
 extern rb_encoding *UTF8_ENCODING;
 
@@ -119,5 +127,7 @@ VALUE cleanup_stmt(query_ctx *ctx);
 
 sqlite3 *Database_sqlite3_db(VALUE self);
 Database_t *self_to_database(VALUE self);
+
+void *gvl_call(enum gvl_mode mode, void *(*fn)(void *), void *data);
 
 #endif /* EXTRALITE_H */

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -179,7 +179,7 @@ static inline VALUE Query_perform_next(VALUE self, int max_rows, VALUE (*call)(q
 
   query_ctx ctx = QUERY_CTX(
     self,
-    query->sqlite3_db,
+    query->db_struct,
     query->stmt,
     Qnil,
     QUERY_MODE(max_rows == SINGLE_ROW ? QUERY_SINGLE_ROW : QUERY_MULTI_ROW),
@@ -391,7 +391,7 @@ VALUE Query_execute_multi(VALUE self, VALUE parameters) {
 
   query_ctx ctx = QUERY_CTX(
     self,
-    query->sqlite3_db,
+    query->db_struct,
     query->stmt,
     parameters,
     QUERY_MODE(QUERY_MULTI_ROW),

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -177,15 +177,14 @@ static inline VALUE Query_perform_next(VALUE self, int max_rows, VALUE (*call)(q
   if (!query->stmt) query_reset(query);
   if (query->eof) return rb_block_given_p() ? self : Qnil;
 
-  query_ctx ctx = {
+  query_ctx ctx = QUERY_CTX(
     self,
     query->sqlite3_db,
     query->stmt,
     Qnil,
     QUERY_MODE(max_rows == SINGLE_ROW ? QUERY_SINGLE_ROW : QUERY_MULTI_ROW),
-    MAX_ROWS(max_rows),
-    0
-  };
+    MAX_ROWS(max_rows)
+  );
   VALUE result = call(&ctx);
   query->eof = ctx.eof;
   return (ctx.mode == QUERY_YIELD) ? self : result;
@@ -390,7 +389,14 @@ VALUE Query_execute_multi(VALUE self, VALUE parameters) {
   if (!query->stmt)
     prepare_single_stmt(query->sqlite3_db, &query->stmt, query->sql);
 
-  query_ctx ctx = { self, query->sqlite3_db, query->stmt, parameters, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS };
+  query_ctx ctx = QUERY_CTX(
+    self,
+    query->sqlite3_db,
+    query->stmt,
+    parameters,
+    QUERY_MODE(QUERY_MULTI_ROW),
+    ALL_ROWS
+  );
   return safe_execute_multi(&ctx);
 }
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,3 +5,5 @@ require 'extralite'
 require 'minitest/autorun'
 
 puts "sqlite3 version: #{Extralite.sqlite3_version}"
+
+IS_LINUX = RUBY_PLATFORM =~ /linux/

--- a/test/issue-38.rb
+++ b/test/issue-38.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "sqlite3"
-require "extralite"
+require "./lib/extralite"
 require "benchmark"
 
 # Setup
@@ -41,7 +41,7 @@ end
 # Benchmark variations
 
 THREAD_COUNTS = [1, 2, 4, 8]
-LIMITS = [1000]#[10, 100, 1000]
+LIMITS = [10, 100, 1000]
 CLIENTS = %w[extralite sqlite3]
 
 # Benchmark

--- a/test/perf_ary.rb
+++ b/test/perf_ary.rb
@@ -12,15 +12,18 @@ end
 require 'benchmark/ips'
 require 'fileutils'
 
-DB_PATH = '/tmp/extralite_sqlite3_perf.db'
+DB_PATH = "/tmp/extralite_sqlite3_perf-#{Time.now.to_i}-#{rand(10000)}.db"
+puts "DB_PATH = #{DB_PATH.inspect}"
+
 
 def prepare_database(count)
-  FileUtils.rm(DB_PATH) rescue nil
   db = Extralite::Database.new(DB_PATH)
-  db.query('create table foo ( a integer primary key, b text )')
+  db.query('create table if not exists foo ( a integer primary key, b text )')
+  db.query('delete from foo')
   db.query('begin')
   count.times { db.query('insert into foo (b) values (?)', "hello#{rand(1000)}" )}
   db.query('commit')
+  db.close
 end
 
 def sqlite3_run(count)

--- a/test/perf_hash.rb
+++ b/test/perf_hash.rb
@@ -12,15 +12,17 @@ end
 require 'benchmark/ips'
 require 'fileutils'
 
-DB_PATH = '/tmp/extralite_sqlite3_perf.db'
+DB_PATH = "/tmp/extralite_sqlite3_perf-#{Time.now.to_i}-#{rand(10000)}.db"
+puts "DB_PATH = #{DB_PATH.inspect}"
 
 def prepare_database(count)
-  FileUtils.rm(DB_PATH) rescue nil
   db = Extralite::Database.new(DB_PATH)
-  db.query('create table foo ( a integer primary key, b text )')
+  db.query('create table if not exists foo ( a integer primary key, b text )')
+  db.query('delete from foo')
   db.query('begin')
   count.times { db.query('insert into foo (b) values (?)', "hello#{rand(1000)}" )}
   db.query('commit')
+  db.close
 end
 
 def sqlite3_run(count)
@@ -36,7 +38,7 @@ def extralite_run(count)
 end
 
 [10, 1000, 100000].each do |c|
-  puts; puts; puts "Record count: #{c}"
+  puts "Record count: #{c}"
 
   prepare_database(c)
 
@@ -48,4 +50,5 @@ end
 
     x.compare!
   end
+  puts; puts; 
 end


### PR DESCRIPTION
This PR implements a per-database GVL release threshold that controls how often the GVL is
released while iterating over records. This PR is a fix to #38, and an alternative to #39,
which solves the problem by using GVL modes.
