### PR TITLE
Improve batch execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ db.execute('insert into foo values (?)', 'Hello, 世界!'.force_encoding(Encodin
 db.batch_execute('insert into foo values (?)', ['bar', 'baz'])
 db.batch_execute('insert into foo values (?, ?)', [[1, 2], [3, 4]])
 
+# batch execute from enumerable
+db.batch_execute('insert into foo values (?)', 1..10)
+
+# batch execute from block
+source = [[1, 2], [2, 3], [3, 4]]
+db.batch_execute('insert into foo values (?, ?)') { source.shift }
+
 # prepared queries
 query = db.prepare('select ? as foo, ? as bar') #=> Extralite::Query
 query.bind(1, 2) #=> [{ :foo => 1, :bar => 2 }]

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ db.execute('insert into foo values (?)', Extralite::Blob.new('Hello, 世界!'))
 db.execute('insert into foo values (?)', 'Hello, 世界!'.force_encoding(Encoding::ASCII_8BIT))
 
 # insert multiple rows
-db.execute_multi('insert into foo values (?)', ['bar', 'baz'])
-db.execute_multi('insert into foo values (?, ?)', [[1, 2], [3, 4]])
+db.batch_execute('insert into foo values (?)', ['bar', 'baz'])
+db.batch_execute('insert into foo values (?, ?)', [[1, 2], [3, 4]])
 
 # prepared queries
 query = db.prepare('select ? as foo, ? as bar') #=> Extralite::Query

--- a/ext/extralite/common.c
+++ b/ext/extralite/common.c
@@ -434,7 +434,7 @@ VALUE safe_query_single_value(query_ctx *ctx) {
   return value;
 }
 
-VALUE safe_execute_multi(query_ctx *ctx) {
+VALUE safe_batch_execute(query_ctx *ctx) {
   int count = RARRAY_LEN(ctx->params);
   int changes = 0;
 

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -348,15 +348,19 @@ VALUE Database_execute(int argc, VALUE *argv, VALUE self) {
 
 /* call-seq:
  *   db.batch_execute(sql, params_array) -> changes
+ *   db.batch_execute(sql, enumerable) -> changes
+ *   db.batch_execute(sql, callable) -> changes
  *   db.batch_execute(sql) { ... } -> changes
  *
- * Executes the given query for each list of parameters in params_array. If a
- * block is given, the block is called for each iteration, and its return value
- * is used as parameters for the query. To stop iteration, the block should
- * return nil.
+ * Executes the given query for each list of parameters in params_array. If an
+ * enumerable is given, it is iterated and each of its values is used as the
+ * parameters for running the query. If a callable is given, it is called
+ * repeatedly and each of its return values is used as the parameters, until nil
+ * is returned. If a block is given, the block is called for each iteration, and
+ * its return value is used as parameters for the query, until nil is returned.
  *
  * Returns the number of changes effected. This method is designed for inserting
- * multiple records.
+ * multiple records or performing other mass operations.
  *
  *     records = [
  *       [1, 2, 3],
@@ -369,7 +373,10 @@ VALUE Database_execute(int argc, VALUE *argv, VALUE self) {
  *       [4, 5, 6]
  *     ]
  *     db.batch_execute('insert into foo values (?, ?, ?)') { records.shift }
- * 
+ *
+ * @param sql [String] query SQL
+ * @param parameters [Array<Array, Hash>, Enumerable, Enumerator, Callable] array of parameters to run query with
+ * @return [Integer] Total number of changes effected
  */
 VALUE Database_batch_execute(int argc, VALUE *argv, VALUE self) {
   Database_t *db = self_to_open_database(self);

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -13,6 +13,7 @@ VALUE eArgumentError;
 
 ID ID_bind;
 ID ID_call;
+ID ID_each;
 ID ID_keys;
 ID ID_new;
 ID ID_strip;
@@ -375,7 +376,7 @@ VALUE Database_execute(int argc, VALUE *argv, VALUE self) {
  *     end
  * 
  */
-VALUE Database_batch_execute(VALUE self, VALUE sql, VALUE params_array) {
+VALUE Database_batch_execute(VALUE self, VALUE sql, VALUE params) {
   Database_t *db = self_to_open_database(self);
   sqlite3_stmt *stmt;
 
@@ -383,7 +384,7 @@ VALUE Database_batch_execute(VALUE self, VALUE sql, VALUE params_array) {
 
   // prepare query ctx
   prepare_single_stmt(db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, params_array, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, params, QUERY_MULTI_ROW, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_execute), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -871,6 +872,7 @@ void Init_ExtraliteDatabase(void) {
 
   ID_bind   = rb_intern("bind");
   ID_call   = rb_intern("call");
+  ID_each   = rb_intern("each");
   ID_keys   = rb_intern("keys");
   ID_new    = rb_intern("new");
   ID_strip  = rb_intern("strip");

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -100,7 +100,7 @@ enum gvl_mode {
 
 extern rb_encoding *UTF8_ENCODING;
 
-VALUE safe_execute_multi(query_ctx *ctx);
+VALUE safe_batch_execute(query_ctx *ctx);
 VALUE safe_query_ary(query_ctx *ctx);
 VALUE safe_query_changes(query_ctx *ctx);
 VALUE safe_query_columns(query_ctx *ctx);

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -32,6 +32,7 @@ extern VALUE cInterruptError;
 extern VALUE cParameterError;
 
 extern ID ID_call;
+extern ID ID_each;
 extern ID ID_keys;
 extern ID ID_new;
 extern ID ID_strip;

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -402,7 +402,13 @@ VALUE Query_execute_chevrons(VALUE self, VALUE params) {
   return self;
 }
 
-/* Executes the query for each set of parameters in the given array. Parameters
+/* call-seq:
+ *   query.batch_execute(params_array) -> changes
+ *   query.batch_execute(enumerable) -> changes
+ *   query.batch_execute(callable) -> changes
+ *   query.batch_execute { ... } -> changes
+ *
+ * Executes the query for each set of parameters in the given array. Parameters
  * can be specified as either an array (for unnamed parameters) or a hash (for
  * named parameters). Returns the number of changes effected. This method is
  * designed for inserting multiple records.
@@ -413,8 +419,14 @@ VALUE Query_execute_chevrons(VALUE self, VALUE params) {
  *       [4, 5, 6]
  *     ]
  *     query.batch_execute(records)
+ * 
+ *     source = [
+ *       [1, 2, 3],
+ *       [4, 5, 6]
+ *     ]
+ *     query.batch_execute { records.shift }
  *
- * @param parameters [Array<Array, Hash>] array of parameters to run query with
+ * @param parameters [Array<Array, Hash>, Enumerable, Enumerator, Callable] array of parameters to run query with
  * @return [Integer] number of changes effected
  */
 VALUE Query_batch_execute(int argc, VALUE *argv, VALUE self) {

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -412,12 +412,12 @@ VALUE Query_execute_chevrons(VALUE self, VALUE params) {
  *       [1, 2, 3],
  *       [4, 5, 6]
  *     ]
- *     query.execute_multi(records)
+ *     query.batch_execute(records)
  *
  * @param parameters [Array<Array, Hash>] array of parameters to run query with
  * @return [Integer] number of changes effected
  */
-VALUE Query_execute_multi(VALUE self, VALUE parameters) {
+VALUE Query_batch_execute(VALUE self, VALUE parameters) {
   Query_t *query = self_to_query(self);
   if (query->closed) rb_raise(cError, "Query is closed");
 
@@ -432,7 +432,7 @@ VALUE Query_execute_multi(VALUE self, VALUE parameters) {
     QUERY_MODE(QUERY_MULTI_ROW),
     ALL_ROWS
   );
-  return safe_execute_multi(&ctx);
+  return safe_batch_execute(&ctx);
 }
 
 /* Returns the database associated with the query.
@@ -570,7 +570,7 @@ void Init_ExtraliteQuery(void) {
   rb_define_method(cQuery, "eof?", Query_eof_p, 0);
   rb_define_method(cQuery, "execute", Query_execute, -1);
   rb_define_method(cQuery, "<<", Query_execute_chevrons, 1);
-  rb_define_method(cQuery, "execute_multi", Query_execute_multi, 1);
+  rb_define_method(cQuery, "batch_execute", Query_batch_execute, 1);
   rb_define_method(cQuery, "initialize", Query_initialize, 2);
   rb_define_method(cQuery, "inspect", Query_inspect, 0);
 

--- a/lib/extralite.rb
+++ b/lib/extralite.rb
@@ -38,6 +38,8 @@ module Extralite
         AND name NOT LIKE 'sqlite_%';
     SQL
 
+    alias_method :execute_multi, :batch_execute
+
     # Returns the list of currently defined tables.
     #
     # @return [Array] list of tables
@@ -89,5 +91,9 @@ module Extralite
     def pragma_get(key)
       query("pragma #{key}")
     end
+  end
+
+  class Query
+    alias_method :execute_multi, :batch_execute
   end
 end

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -367,6 +367,22 @@ class DatabaseTest < MiniTest::Test
     ], @db.query('select * from foo')
   end
 
+  def test_batch_execute_with_block
+    source = [42, 43, 44]
+
+    @db.query('create table foo (a)')
+    assert_equal [], @db.query('select * from foo')
+
+    changes = @db.batch_execute('insert into foo values (?)') { source.shift }
+
+    assert_equal 3, changes
+    assert_equal [
+      { a: 42 },
+      { a: 43 },
+      { a: 44 }
+    ], @db.query('select * from foo')
+  end
+
   def test_interrupt
     t = Thread.new do
       sleep 0.5

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -317,7 +317,7 @@ class DatabaseTest < MiniTest::Test
     assert_equal [[1, 2, 3], [42, 5, 6]], @db.query_ary('select * from t order by x')
   end
 
-  def test_execute_multi
+  def test_batch_execute
     @db.query('create table foo (a, b, c)')
     assert_equal [], @db.query('select * from foo')
 
@@ -326,7 +326,7 @@ class DatabaseTest < MiniTest::Test
       ['4', 5, 6]
     ]
 
-    changes = @db.execute_multi('insert into foo values (?, ?, ?)', records)
+    changes = @db.batch_execute('insert into foo values (?, ?, ?)', records)
 
     assert_equal 2, changes
     assert_equal [
@@ -335,7 +335,7 @@ class DatabaseTest < MiniTest::Test
     ], @db.query('select * from foo')
   end
 
-  def test_execute_multi_single_values
+  def test_batch_execute_single_values
     @db.query('create table foo (bar)')
     assert_equal [], @db.query('select * from foo')
 
@@ -344,7 +344,7 @@ class DatabaseTest < MiniTest::Test
       'bye'
     ]
 
-    changes = @db.execute_multi('insert into foo values (?)', records)
+    changes = @db.batch_execute('insert into foo values (?)', records)
 
     assert_equal 2, changes
     assert_equal [
@@ -631,14 +631,14 @@ class ScenarioTest < MiniTest::Test
     t1 = Thread.new do
       data = (1..50).each_slice(10).map { |a| a.map { |i| [i, i + 1, i + 2] } }
       data.each do |params|
-        q1.execute_multi(params)
+        q1.batch_execute(params)
       end
     end
 
     t2 = Thread.new do
       data = (51..100).each_slice(10).map { |a| a.map { |i| [i, i + 1, i + 2] } }
       data.each do |params|
-        q2.execute_multi(params)
+        q2.batch_execute(params)
       end
     end
 

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -353,6 +353,20 @@ class DatabaseTest < MiniTest::Test
     ], @db.query('select * from foo')
   end
 
+  def test_batch_execute_with_each_interface
+    @db.query('create table foo (bar)')
+    assert_equal [], @db.query('select * from foo')
+
+    changes = @db.batch_execute('insert into foo values (?)', 1..3)
+
+    assert_equal 3, changes
+    assert_equal [
+      { bar: 1 },
+      { bar: 2 },
+      { bar: 3 }
+    ], @db.query('select * from foo')
+  end
+
   def test_interrupt
     t = Thread.new do
       sleep 0.5

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -496,7 +496,7 @@ class QueryTest < MiniTest::Test
   end
 
 
-  def test_query_execute_multi
+  def test_query_batch_execute
     @db.query('create table foo (a, b, c)')
     assert_equal [], @db.query('select * from foo')
 
@@ -506,7 +506,7 @@ class QueryTest < MiniTest::Test
     ]
 
     p = @db.prepare('insert into foo values (?, ?, ?)')
-    changes = p.execute_multi(records)
+    changes = p.batch_execute(records)
 
     assert_equal 2, changes
     assert_equal [

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -515,6 +515,21 @@ class QueryTest < MiniTest::Test
     ], @db.query('select * from foo')
   end
 
+  def test_query_batch_execute_with_each_interface
+    @db.query('create table foo (a)')
+    assert_equal [], @db.query('select * from foo')
+
+    p = @db.prepare('insert into foo values (?)')
+    changes = p.batch_execute(1..3)
+
+    assert_equal 3, changes
+    assert_equal [
+      { a: 1 },
+      { a: 2 },
+      { a: 3 }
+    ], @db.query('select * from foo')
+  end
+
   def test_query_status
     assert_equal 0, @query.status(Extralite::SQLITE_STMTSTATUS_RUN)
     @query.to_a

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -530,6 +530,23 @@ class QueryTest < MiniTest::Test
     ], @db.query('select * from foo')
   end
 
+  def test_query_batch_execute_with_block
+    source = [42, 43, 44]
+
+    @db.query('create table foo (a)')
+    assert_equal [], @db.query('select * from foo')
+
+    p = @db.prepare('insert into foo values (?)')
+    changes = p.batch_execute { source.shift }
+
+    assert_equal 3, changes
+    assert_equal [
+      { a: 42 },
+      { a: 43 },
+      { a: 44 }
+    ], @db.query('select * from foo')
+  end
+
   def test_query_status
     assert_equal 0, @query.status(Extralite::SQLITE_STMTSTATUS_RUN)
     @query.to_a


### PR DESCRIPTION
This PR improves the batch execute API (fix #47)

- Rename `#execute_multi` to `#batch_execute`. `#execute_multi` is still available but will 
  be deprecated eventually.
- Add support for batch query execution with any enumerable. This can be done with any object
  that responds to `#each`.
- Add support for batch query execution with a block, or by calling with a callable.
