### PR TITLE
Streamline and improve query methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,11 @@ instantiate an iterator explicitly:
 iterator = Extralite::Iterator(query, :hash)
 ```
 
+### Value Conversion in Prepared Queries
+
+Prepared queries can automatically convert their result sets to arbitrary Ruby
+objects. This is useful when you need to transform values, such as 
+
 ## Batch Execution of Queries
 
 Extralite provides methods for batch execution of queries, with multiple sets of

--- a/README.md
+++ b/README.md
@@ -238,19 +238,19 @@ Transforms are useful when you need to transform rows into ORM model instances,
 or when you need to do some other transformation on the values retrieved from
 the database.
 
-To transform rows as hashes, use `#query_transform_hash`:
+To transform results, pass a transform proc as the first parameter to `#query`:
 
 ```ruby
 transform = ->(h) { MyModel.new(h) }
-db.query_transform_hash(transform, 'select * from foo')
+db.query(transform, 'select * from foo')
 #=> rows as instances of MyModel
 ```
 
-To transform rows as lists of values, use `#query_transform_argv`:
+To transform rows as lists of values, use `#query_argv`:
 
 ```ruby
 transform = ->(a, b, c) { { a:a, b: b, c: JSON.parse(c) } }
-db.query_transform_argv(transform, 'select a, b, c from foo')
+db.query_argv(transform, 'select a, b, c from foo')
 #=> transformed rows
 ```
 
@@ -407,7 +407,7 @@ Setting a transform will only affect the following methods: `#to_a`, `#next`,
 `#each` and `#batch_query`. All other methods will behave the same even if a
 transform is set.
 
-To set a hash transform use `#transform_hash`:
+To set a hash transform use `#transform`:
 
 ```ruby
 q = db.prepare('select * from items where id = ?')

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ latest features and enhancements.
   [sqlite3](https://github.com/sparklemotion/sqlite3-ruby) gem).
 - Support for [concurrency](#concurrency) out of the box for multi-threaded
   and multi-fibered apps.
-- A variety of methods for [retrieving data](#basic-usage) - hashes, array, single rows, single
-  values.
+- A variety of ways to [retrieve data](#query-modes) - hashes, arrays, single
+  columns, single rows, [transforms](#value-transforms).
 - Support for [external iteration](#iterating-over-records-in-a-prepared-query),
   allowing iterating through single records or batches of records.
 - [Prepared queries](#prepared-queries).

--- a/README.md
+++ b/README.md
@@ -400,16 +400,12 @@ iterator.each { |r| ... }
 ### Value Transforms in Prepared Queries
 
 Prepared queries can automatically transform their result sets by providing a
-transform block. The transform is done either on a hash (useful when you need to
-return ORM instances from your queries), or on a list of values (useful when you
-need to make additional transformations on specific fields, such as JSON
-fields).
-
-To set a hash transform use `#transform`:
+transform block. The transform block receives values according to the query mode
+(hash, array or argv). To set a transform use `#transform`:
 
 ```ruby
 q = db.prepare('select * from items where id = ?')
-q.transform_hash { |h| Item.new(h) }
+q.transform { |h| Item.new(h) }
 
 q.bind(42).next #=> Item instance
 ```

--- a/examples/kv_store.rb
+++ b/examples/kv_store.rb
@@ -24,12 +24,12 @@ class KVStore
   end
 
   def setup_queries
-    @q_get = @db.prepare('select value from kv where key = ?')
+    @q_get = @db.prepare_argv('select value from kv where key = ?')
     @q_set = @db.prepare('insert into kv (key, value) values($1, $2) on conflict (key) do update set value = $2')
   end
 
   def get(key)
-    @q_get.bind(key).next_single_column
+    @q_get.bind(key).next
   end
 
   def set(key, value)

--- a/examples/multi_fiber.rb
+++ b/examples/multi_fiber.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require './lib/extralite'
+require 'fiber'
+
+f1 = Fiber.new do |f2|
+  while true
+    STDOUT << '.'
+    f2 = f2.transfer
+  end
+end
+
+db = Extralite::Database.new(':memory:')
+db.on_progress(1) { f1.transfer(Fiber.current) }
+
+p db.query('select 1, 2, 3')

--- a/examples/pubsub_store_polyphony.rb
+++ b/examples/pubsub_store_polyphony.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+require 'bundler/inline'
+
+gemfile do
+  gem 'polyphony'
+  gem 'extralite', path: '.'
+  gem 'benchmark-ips'
+end
+
+require 'tempfile'
+
+class PubSub
+  def initialize(db)
+    @db = db
+  end
+
+  def attach
+    @db.execute('insert into subscribers (stamp) values (?)', Time.now.to_i)
+    @id = @db.last_insert_rowid
+  end
+
+  def detach
+    @db.execute('delete from subscribers where id = ?', @id)
+  end
+
+  def subscribe(*topics)
+    @db.transaction do
+      topics.each do |t|
+        @db.execute('insert into subscriber_topics (subscriber_id, topic) values (?, ?)', @id, t)
+      end
+    end
+  end
+
+  def unsubscribe(*topics)
+    @db.transaction do
+      topics.each do |t|
+        @db.execute('delete from subscriber_topics where subscriber_id = ? and topic = ?', @id, t)
+      end
+    end
+  end
+
+  def get_messages(&block)
+    @db.transaction do
+      @db.execute('update subscribers set stamp = ? where id = ?', Time.now.to_i, @id)
+      @db.query_argv('delete from messages where subscriber_id = ? returning topic, message', @id, &block)
+    end
+  end
+
+  SCHEMA = <<~SQL
+    PRAGMA foreign_keys = ON;
+
+    create table if not exists subscribers (
+      id integer primary key,
+      stamp float
+    );
+    create index if not exists idx_subscribers_stamp on subscribers (stamp);
+
+    create table if not exists subscriber_topics (
+      subscriber_id integer references subscribers(id) on delete cascade,
+      topic text
+    );
+
+    create table if not exists messages(
+      subscriber_id integer,
+      topic text,
+      message text, 
+      foreign key (subscriber_id, topic)
+        references subscriber_topics(subscriber_id, topic)
+        on delete cascade
+    );
+    create index if not exists idx_messages_subscriber_id_topic on messages (subscriber_id, topic);
+  SQL
+
+  def setup
+    @db.transaction do
+      @db.execute(SCHEMA)
+    end
+  end
+
+  def publish(topic, message)
+    @db.execute("
+      with subscribed as (
+        select subscriber_id
+        from subscriber_topics
+        where topic = $1
+      )
+      insert into messages
+      select subscriber_id, $1, $2
+      from subscribed
+    ", topic, message)
+  end
+
+  def prune_subscribers
+    @db.execute('delete from subscribers where stamp < ?', Time.now.to_i - 3600)
+  end
+end
+
+fn = Tempfile.new('pubsub_store').path
+p fn: fn
+db1 = Extralite::Database.new(fn)
+db1.pragma(journal_mode: :wal, synchronous: 1)
+db2 = Extralite::Database.new(fn)
+db2.pragma(journal_mode: :wal, synchronous: 1)
+db3 = Extralite::Database.new(fn)
+db3.pragma(journal_mode: :wal, synchronous: 1)
+
+db1.on_progress(50) { |b| b ? sleep(0.0001) : snooze }
+db2.on_progress(50) { |b| b ? sleep(0.0001) : snooze }
+db3.on_progress(50) { |b| b ? sleep(0.0001) : snooze }
+
+producer = PubSub.new(db1)
+producer.setup
+
+consumer1 = PubSub.new(db2)
+consumer1.setup
+consumer1.attach
+consumer1.subscribe('foo', 'bar')
+
+consumer2 = PubSub.new(db3)
+consumer2.setup
+consumer2.attach
+consumer2.subscribe('foo', 'baz')
+
+
+# producer.publish('foo', 'foo1')
+# producer.publish('bar', 'bar1')
+# producer.publish('baz', 'baz1')
+
+# puts "- get messages"
+# consumer1.get_messages { |t, m| p consumer: 1, topic: t, message: m }
+# consumer2.get_messages { |t, m| p consumer: 2, topic: t, message: m }
+
+# puts "- get messages again"
+# consumer1.get_messages { |t, m| p consumer: 1, topic: t, message: m }
+# consumer2.get_messages { |t, m| p consumer: 2, topic: t, message: m }
+
+topics = %w{bar baz}
+
+publish_count = 0
+f1 = spin do
+  while true
+    message = "message#{rand(1000)}"
+    producer.publish(topics.sample, message)
+
+    publish_count += 1
+    snooze
+  end
+end
+
+receive_count = 0
+f2 = spin do
+  while true
+    consumer1.get_messages { |t, m| receive_count += 1 }
+    sleep 0.1
+  end
+end
+
+f3 = spin do
+  while true
+    consumer2.get_messages { |t, m| receive_count += 1 }
+    sleep 0.1
+  end
+end
+
+db4 = Extralite::Database.new(fn)
+db4.pragma(journal_mode: :wal, synchronous: 1)
+db4.on_progress(10) { sleep 0.05 }
+
+last_t = Time.now
+last_publish_count = 0
+last_receive_count = 0
+while true
+  sleep 1
+  now = Time.now
+  elapsed = now - last_t
+  d_publish = publish_count - last_publish_count
+  d_receive = receive_count - last_receive_count
+  pending = db4.query_single_argv('select count(*) from messages')
+  puts "#{Time.now} publish: #{d_publish/elapsed}/s receive: #{d_receive/elapsed}/s pending: #{pending}"
+  last_t = now
+  last_publish_count = publish_count
+  last_receive_count = receive_count
+end
+
+# bm = Benchmark.ips do |x|
+#   x.config(:time => 10, :warmup => 2)
+
+#   x.report("pubsub") do
+#     db.transaction { 10.times { |i| producer.publish('foo', "foo#{i}") } }
+#     consumer1.get_messages
+#     consumer2.get_messages
+#   end
+
+#   x.compare!
+# end

--- a/examples/pubsub_store_polyphony.rb
+++ b/examples/pubsub_store_polyphony.rb
@@ -41,10 +41,8 @@ class PubSub
   end
 
   def get_messages(&block)
-    @db.transaction do
-      @db.execute('update subscribers set stamp = ? where id = ?', Time.now.to_i, @id)
+    #   @db.execute('update subscribers set stamp = ? where id = ?', Time.now.to_i, @id)
       @db.query_argv('delete from messages where subscriber_id = ? returning topic, message', @id, &block)
-    end
   end
 
   SCHEMA = <<~SQL

--- a/examples/pubsub_store_threads.rb
+++ b/examples/pubsub_store_threads.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require './lib/extralite'
+require 'tempfile'
+
+class PubSub
+  def initialize(db)
+    @db = db
+  end
+
+  def attach
+    @db.execute('insert into subscribers (stamp) values (?)', Time.now.to_i)
+    @id = @db.last_insert_rowid
+  end
+
+  def detach
+    @db.execute('delete from subscribers where id = ?', @id)
+  end
+
+  def subscribe(*topics)
+    @db.transaction do
+      topics.each do |t|
+        @db.execute('insert into subscriber_topics (subscriber_id, topic) values (?, ?)', @id, t)
+      end
+    end
+  end
+
+  def unsubscribe(*topics)
+    @db.transaction do
+      topics.each do |t|
+        @db.execute('delete from subscriber_topics where subscriber_id = ? and topic = ?', @id, t)
+      end
+    end
+  end
+
+  def get_messages(&block)
+      messages = @db.query_ary('delete from messages where subscriber_id = ? returning topic, message', @id)
+      if block
+        messages.each(&block)
+        nil
+      else
+        messages
+      end
+    # end
+  rescue Extralite::BusyError
+    p busy: :get_message
+    block_given? ? nil : []
+  end
+
+  SCHEMA = <<~SQL
+    PRAGMA foreign_keys = ON;
+
+    create table if not exists subscribers (
+      id integer primary key,
+      stamp float
+    );
+    create index if not exists idx_subscribers_stamp on subscribers (stamp);
+
+    create table if not exists subscriber_topics (
+      subscriber_id integer references subscribers(id) on delete cascade,
+      topic text
+    );
+
+    create table if not exists messages(
+      subscriber_id integer,
+      topic text,
+      message text,
+      foreign key (subscriber_id, topic)
+        references subscriber_topics(subscriber_id, topic)
+        on delete cascade
+    );
+    create index if not exists idx_messages_subscriber_id_topic on messages (subscriber_id, topic);
+  SQL
+
+  def setup
+    @db.transaction do
+      @db.execute(SCHEMA)
+    end
+  end
+
+  def publish(topic, message)
+    # @db.transaction do
+      @db.execute("
+        with subscribed as (
+          select subscriber_id
+          from subscriber_topics
+          where topic = $1
+        )
+        insert into messages
+        select subscriber_id, $1, $2
+        from subscribed
+      ", topic, message)
+    # end
+  rescue Extralite::BusyError
+    p busy: :publish
+    retry
+  end
+
+  def prune_subscribers
+    @db.execute('delete from subscribers where stamp < ?', Time.now.to_i - 3600)
+  end
+end
+
+fn = Tempfile.new('pubsub_store').path
+p fn
+db1 = Extralite::Database.new(fn)
+db1.busy_timeout = 0.1
+db1.pragma(journal_mode: :wal, synchronous: 1)
+db1.gvl_release_threshold = -1
+db2 = Extralite::Database.new(fn)
+db2.pragma(journal_mode: :wal, synchronous: 1)
+db2.busy_timeout = 0.1
+db2.gvl_release_threshold = -1
+db3 = Extralite::Database.new(fn)
+db3.pragma(journal_mode: :wal, synchronous: 1)
+db3.busy_timeout = 0.1
+db3.gvl_release_threshold = -1
+
+# db1.on_progress(100) { Thread.pass }
+# db2.on_progress(100) { Thread.pass }
+# db3.on_progress(100) { Thread.pass }
+
+producer = PubSub.new(db1)
+producer.setup
+
+consumer1 = PubSub.new(db2)
+consumer1.setup
+consumer1.attach
+consumer1.subscribe('foo', 'bar')
+
+consumer2 = PubSub.new(db3)
+consumer2.setup
+consumer2.attach
+consumer2.subscribe('foo', 'baz')
+
+# producer.publish('foo', 'foo1')
+# producer.publish('bar', 'bar1')
+# producer.publish('baz', 'baz1')
+
+# puts "- get messages"
+# consumer1.get_messages { |t, m| p consumer: 1, topic: t, message: m }
+# consumer2.get_messages { |t, m| p consumer: 2, topic: t, message: m }
+
+# puts "- get messages again"
+# consumer1.get_messages { |t, m| p consumer: 1, topic: t, message: m }
+# consumer2.get_messages { |t, m| p consumer: 2, topic: t, message: m }
+
+topics = %w{bar baz}
+
+publish_count = 0
+t1 = Thread.new do
+  while true
+    message = "message#{rand(1000)}"
+    producer.publish(topics.sample, message)
+
+    publish_count += 1
+    Thread.pass
+  end
+end
+
+receive_count = 0
+
+t2 = Thread.new do
+  while true
+    consumer1.get_messages { |t, m| receive_count += 1 }
+    sleep(0.1)
+  end
+end
+
+t3 = Thread.new do
+  while true
+    consumer2.get_messages { |t, m| receive_count += 1 }
+    sleep(0.1)
+  end
+end
+
+db4 = Extralite::Database.new(fn)
+db4.pragma(journal_mode: :wal, synchronous: 1)
+db4.gvl_release_threshold = -1
+db4.busy_timeout = 3
+
+last_t = Time.now
+last_publish_count = 0
+last_receive_count = 0
+while true
+  sleep 1
+  now = Time.now
+  elapsed = now - last_t
+  d_publish = publish_count - last_publish_count
+  d_receive = receive_count - last_receive_count
+
+  count = db4.query_single_argv('select count(*) from messages')
+  puts "#{Time.now} publish: #{d_publish/elapsed}/s receive: #{d_receive/elapsed}/s pending: #{count}"
+  last_t = now
+  last_publish_count = publish_count
+  last_receive_count = receive_count
+end

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -182,10 +182,9 @@ VALUE Database_read_only_p(VALUE self) {
   return (open == 1) ? Qtrue : Qfalse;
 }
 
-/* call-seq:
- *   db.close -> db
- *
- * Closes the database.
+/* Closes the database.
+ * 
+ * @return [Extralite::Database] database
  */
 VALUE Database_close(VALUE self) {
   int rc;
@@ -265,45 +264,46 @@ static inline VALUE Database_perform_query(int argc, VALUE *argv, VALUE self, VA
  *     db.query('select * from foo where x = ?', 42)
  *
  * Named placeholders are specified using `:`. The placeholder values are
- * specified using a hash, where keys are either strings are symbols. String
- * keys can include or omit the `:` prefix. The following are equivalent:
+ * specified using keyword arguments:
  *
  *     db.query('select * from foo where x = :bar', bar: 42)
- *     db.query('select * from foo where x = :bar', 'bar' => 42)
- *     db.query('select * from foo where x = :bar', ':bar' => 42)
+ * 
+ * @overload query(sql, ...)
+ *   @param sql [String] SQL statement
+ *   @return [Array<Hash>, Integer] rows or total changes
+ * @overload query(transform, sql, ...)
+ *   @param transform [Proc] transform proc
+ *   @param sql [String] SQL statement
+ *   @return [Array<Hash>, Integer] rows or total changes
  */
 VALUE Database_query(int argc, VALUE *argv, VALUE self) {
   return Database_perform_query(argc, argv, self, safe_query_hash, QUERY_HASH);
 }
 
-/* call-seq:
- *    db.query_argv(transform, sql, *parameters, &block) -> [...]
- *
- * Runs a query and transforms rows through the given transform poc. Each row is
+/* Runs a query and transforms rows through the given transform poc. Each row is
  * provided to the transform proc as a list of values. If a block is given, it
  * will be called for each row. Otherwise, an array containing all rows is
  * returned.
  *
- * Query parameters to be bound to placeholders in the query can be specified as
- * a list of values or as a hash mapping parameter names to values. When
- * parameters are given as an array, the query should specify parameters using
- * `?`:
+ * If a transform block is given, it is called for each row, with the row values
+ * splatted:
  *
  *     transform = ->(a, b, c) { a * 100 + b * 10 + c }
  *     db.query_argv(transform, 'select a, b, c from foo where c = ?', 42)
  *
- * @param transform [Proc] transform proc
- * @param sql [String] SQL query string
- * @return [Array<Hash, any>, Integer] array containing result set or number of rows
+ * @overload query_argv(sql, ...)
+ *   @param sql [String] SQL statement
+ *   @return [Array<Array, any>, Integer] rows or total changes
+ * @overload query_argv(transform, sql, ...)
+ *   @param transform [Proc] transform proc
+ *   @param sql [String] SQL statement
+ *   @return [Array<Array, any>, Integer] rows or total changes
  */
 VALUE Database_query_argv(int argc, VALUE *argv, VALUE self) {
   return Database_perform_query(argc, argv, self, safe_query_argv, QUERY_ARGV);
 }
 
-/* call-seq:
- *   db.query_ary(sql, *parameters, &block) -> [...]
- *
- * Runs a query returning rows as arrays. If a block is given, it will be called
+/* Runs a query returning rows as arrays. If a block is given, it will be called
  * for each row. Otherwise, an array containing all rows is returned.
  *
  * Query parameters to be bound to placeholders in the query can be specified as
@@ -320,16 +320,20 @@ VALUE Database_query_argv(int argc, VALUE *argv, VALUE self) {
  *     db.query_ary('select * from foo where x = :bar', bar: 42)
  *     db.query_ary('select * from foo where x = :bar', 'bar' => 42)
  *     db.query_ary('select * from foo where x = :bar', ':bar' => 42)
+ * 
+ * @overload query_ary(sql, ...)
+ *   @param sql [String] SQL statement
+ *   @return [Array<Array>, Integer] rows or total changes
+ * @overload query_ary(transform, sql, ...)
+ *   @param transform [Proc] transform proc
+ *   @param sql [String] SQL statement
+ *   @return [Array<Array>, Integer] rows or total changes
  */
 VALUE Database_query_ary(int argc, VALUE *argv, VALUE self) {
   return Database_perform_query(argc, argv, self, safe_query_ary, QUERY_ARY);
 }
 
-/* call-seq:
- *   db.query_single(sql, *parameters) -> {...}
- *   db.query_single(transform, sql, *parameters) -> {...}
- *
- * Runs a query returning a single row as a hash.
+/* Runs a query returning a single row as a hash.
  *
  * Query parameters to be bound to placeholders in the query can be specified as
  * a list of values or as a hash mapping parameter names to values. When
@@ -339,22 +343,23 @@ VALUE Database_query_ary(int argc, VALUE *argv, VALUE self) {
  *     db.query_single('select * from foo where x = ?', 42)
  *
  * Named placeholders are specified using `:`. The placeholder values are
- * specified using a hash, where keys are either strings are symbols. String
- * keys can include or omit the `:` prefix. The following are equivalent:
+ * specified using keyword arguments:
  *
  *     db.query_single('select * from foo where x = :bar', bar: 42)
- *     db.query_single('select * from foo where x = :bar', 'bar' => 42)
- *     db.query_single('select * from foo where x = :bar', ':bar' => 42)
+ *
+ * @overload query_single(sql, ...) -> row
+ *   @param sql [String] SQL statement
+ *   @return [Array, any] row
+ * @overload query_single(transform, sql, ...) -> row
+ *   @param transform [Proc] transform proc
+ *   @param sql [String] SQL statement
+ *   @return [Array, any] row
  */
 VALUE Database_query_single(int argc, VALUE *argv, VALUE self) {
   return Database_perform_query(argc, argv, self, safe_query_single_row_hash, QUERY_HASH);
 }
 
-/* call-seq:
- *   db.query_single_argv(sql, *parameters) -> {...}
- *   db.query_single_argv(transform, sql, *parameters) -> {...}
- *
- * Runs a query returning a single row as a hash.
+/* Runs a query returning a single row as an array or a single value.
  *
  * Query parameters to be bound to placeholders in the query can be specified as
  * a list of values or as a hash mapping parameter names to values. When
@@ -364,17 +369,44 @@ VALUE Database_query_single(int argc, VALUE *argv, VALUE self) {
  *     db.query_single_argv('select * from foo where x = ?', 42)
  *
  * Named placeholders are specified using `:`. The placeholder values are
- * specified using a hash, where keys are either strings are symbols. String
- * keys can include or omit the `:` prefix. The following are equivalent:
+ * specified using keyword arguments:
  *
  *     db.query_single_argv('select * from foo where x = :bar', bar: 42)
- *     db.query_single_argv('select * from foo where x = :bar', 'bar' => 42)
- *     db.query_single_argv('select * from foo where x = :bar', ':bar' => 42)
+ * 
+ * @overload query_single_argv(sql, ...) -> row
+ *   @param sql [String] SQL statement
+ *   @return [Array, any] row
+ * @overload query_single_argv(transform, sql, ...) -> row
+ *   @param transform [Proc] transform proc
+ *   @param sql [String] SQL statement
+ *   @return [Array, any] row
  */
 VALUE Database_query_single_argv(int argc, VALUE *argv, VALUE self) {
   return Database_perform_query(argc, argv, self, safe_query_single_row_argv, QUERY_ARGV);
 }
 
+/* Runs a query returning a single row as an array.
+ *
+ * Query parameters to be bound to placeholders in the query can be specified as
+ * a list of values or as a hash mapping parameter names to values. When
+ * parameters are given as an array, the query should specify parameters using
+ * `?`:
+ *
+ *     db.query_single_ary('select * from foo where x = ?', 42)
+ *
+ * Named placeholders are specified using `:`. The placeholder values are
+ * specified using keyword arguments:
+ *
+ *     db.query_single_ary('select * from foo where x = :bar', bar: 42)
+ * 
+ * @overload query_single_ary(sql, ...) -> row
+ *   @param sql [String] SQL statement
+ *   @return [Array, any] row
+ * @overload query_single_ary(transform, sql, ...) -> row
+ *   @param transform [Proc] transform proc
+ *   @param sql [String] SQL statement
+ *   @return [Array, any] row
+ */
 VALUE Database_query_single_ary(int argc, VALUE *argv, VALUE self) {
   return Database_perform_query(argc, argv, self, safe_query_single_row_ary, QUERY_ARY);
 }
@@ -393,21 +425,16 @@ VALUE Database_query_single_ary(int argc, VALUE *argv, VALUE self) {
  *     db.execute('update foo set x = ? where y = ?', 42, 43)
  *
  * Named placeholders are specified using `:`. The placeholder values are
- * specified using a hash, where keys are either strings are symbols. String
- * keys can include or omit the `:` prefix. The following are equivalent:
+ * specified using keyword arguments:
  *
  *     db.execute('update foo set x = :bar', bar: 42)
- *     db.execute('update foo set x = :bar', 'bar' => 42)
- *     db.execute('update foo set x = :bar', ':bar' => 42)
  */
 VALUE Database_execute(int argc, VALUE *argv, VALUE self) {
   return Database_perform_query(argc, argv, self, safe_query_changes, QUERY_HASH);
 }
 
 /* call-seq:
- *   db.batch_execute(sql, params_array) -> changes
- *   db.batch_execute(sql, enumerable) -> changes
- *   db.batch_execute(sql, callable) -> changes
+ *   db.batch_execute(sql, params_source) -> changes
  *
  * Executes the given query for each list of parameters in the paramter source.
  * If an enumerable is given, it is iterated and each of its values is used as
@@ -447,12 +474,8 @@ VALUE Database_batch_execute(VALUE self, VALUE sql, VALUE parameters) {
 }
 
 /* call-seq:
- *   db.batch_query(sql, params_array) -> rows
- *   db.batch_query(sql, enumerable) -> rows
- *   db.batch_query(sql, callable) -> rows
- *   db.batch_query(sql, params_array) { |rows| ... } -> changes
- *   db.batch_query(sql, enumerable) { |rows| ... } -> changes
- *   db.batch_query(sql, callable) { |rows| ... } -> changes
+ *   db.batch_query(sql, params_source) -> rows
+ *   db.batch_query(sql, params_source) { |rows| ... } -> changes
  *
  * Executes the given query for each list of parameters in the given paramter
  * source. If a block is given, it is called with the resulting rows for each
@@ -482,12 +505,8 @@ VALUE Database_batch_query(VALUE self, VALUE sql, VALUE parameters) {
 }
 
 /* call-seq:
- *   db.batch_query_ary(sql, params_array) -> rows
- *   db.batch_query_ary(sql, enumerable) -> rows
- *   db.batch_query_ary(sql, callable) -> rows
- *   db.batch_query_ary(sql, params_array) { |rows| ... } -> changes
- *   db.batch_query_ary(sql, enumerable) { |rows| ... } -> changes
- *   db.batch_query_ary(sql, callable) { |rows| ... } -> changes
+ *   db.batch_query_ary(sql, params_source) -> rows
+ *   db.batch_query_ary(sql, params_source) { |rows| ... } -> changes
  *
  * Executes the given query for each list of parameters in the given paramter
  * source. If a block is given, it is called with the resulting rows for each
@@ -517,12 +536,8 @@ VALUE Database_batch_query_ary(VALUE self, VALUE sql, VALUE parameters) {
 }
 
 /* call-seq:
- *   db.batch_query_argv(sql, params_array) -> rows
- *   db.batch_query_argv(sql, enumerable) -> rows
- *   db.batch_query_argv(sql, callable) -> rows
- *   db.batch_query_argv(sql, params_array) { |rows| ... } -> changes
- *   db.batch_query_argv(sql, enumerable) { |rows| ... } -> changes
- *   db.batch_query_argv(sql, callable) { |rows| ... } -> changes
+ *   db.batch_query_argv(sql, params_source) -> rows
+ *   db.batch_query_argv(sql, params_source) { |rows| ... } -> changes
  *
  * Executes the given query for each list of parameters in the given paramter
  * source. If a block is given, it is called with the resulting rows for each
@@ -551,19 +566,17 @@ VALUE Database_batch_query_argv(VALUE self, VALUE sql, VALUE parameters) {
   return rb_ensure(SAFE(safe_batch_query_argv), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
 
-/* call-seq:
- *   db.columns(sql) -> columns
- *
- * Returns the column names for the given query, without running it.
+/* Returns the column names for the given query, without running it.
+ * 
+ * @return [Array<String>] column names
  */
 VALUE Database_columns(VALUE self, VALUE sql) {
   return Database_perform_query(1, &sql, self, safe_query_columns, QUERY_HASH);
 }
 
-/* call-seq:
- *   db.last_insert_rowid -> int
- *
- * Returns the rowid of the last inserted row.
+/* Returns the rowid of the last inserted row.
+ * 
+ * @return [Integer] last rowid
  */
 VALUE Database_last_insert_rowid(VALUE self) {
   Database_t *db = self_to_open_database(self);
@@ -571,10 +584,9 @@ VALUE Database_last_insert_rowid(VALUE self) {
   return INT2FIX(sqlite3_last_insert_rowid(db->sqlite3_db));
 }
 
-/* call-seq:
- *   db.changes -> int
- *
- * Returns the number of changes made to the database by the last operation.
+/* Returns the number of changes made to the database by the last operation.
+ * 
+ * @return [Integer] number of changes
  */
 VALUE Database_changes(VALUE self) {
   Database_t *db = self_to_open_database(self);
@@ -582,10 +594,14 @@ VALUE Database_changes(VALUE self) {
   return INT2FIX(sqlite3_changes(db->sqlite3_db));
 }
 
-/* call-seq: db.filename -> string db.filename(db_name) -> string
- *
- * Returns the database filename. If db_name is given, returns the filename for
+/* Returns the database filename. If db_name is given, returns the filename for
  * the respective attached database.
+ * 
+ * @overload filename()
+ *   @return [String] database filename
+ * @overload filename(db_name)
+ *   @param db_name [String] attached database name
+ *   @return [String] database filename
  */
 VALUE Database_filename(int argc, VALUE *argv, VALUE self) {
   const char *db_name;
@@ -598,10 +614,9 @@ VALUE Database_filename(int argc, VALUE *argv, VALUE self) {
   return filename ? rb_str_new_cstr(filename) : Qnil;
 }
 
-/* call-seq:
- *   db.transaction_active? -> bool
- *
- * Returns true if a transaction is currently in progress.
+/* Returns true if a transaction is currently in progress.
+ * 
+ * @return [bool] is transaction in progress
  */
 VALUE Database_transaction_active_p(VALUE self) {
   Database_t *db = self_to_open_database(self);
@@ -610,10 +625,10 @@ VALUE Database_transaction_active_p(VALUE self) {
 }
 
 #ifdef HAVE_SQLITE3_LOAD_EXTENSION
-/* call-seq:
- *   db.load_extension(path) -> db
- *
- * Loads an extension with the given path.
+/* Loads an extension with the given path.
+ * 
+ * @param path [String] extension file path
+ * @return [Extralite::Database] database
  */
 VALUE Database_load_extension(VALUE self, VALUE path) {
   Database_t *db = self_to_open_database(self);
@@ -643,33 +658,60 @@ static inline VALUE Database_prepare(int argc, VALUE *argv, VALUE self, VALUE mo
 /* call-seq:
  *   db.prepare(sql) -> Extralite::Query
  *   db.prepare(sql, ...) -> Extralite::Query
- *   db.prepare(sql) { ... } -> Extralite::Query
+ *   db.prepare(sql, ...) { ... } -> Extralite::Query
  *
- * Creates a prepared statement with the given SQL query in hash mode. If query
+ * Creates a prepared query with the given SQL query in hash mode. If query
  * parameters are given, they are bound to the query. If a block is given, it is
  * used as a transform proc.
+ * 
+ * @param sql [String] SQL statement
+ * @return [Extralite::Query] prepared query
  */
 VALUE Database_prepare_hash(int argc, VALUE *argv, VALUE self) {
   return Database_prepare(argc, argv, self, SYM_hash);
 }
 
+/* call-seq:
+ *   db.prepare_argv(sql) -> Extralite::Query
+ *   db.prepare_argv(sql, ...) -> Extralite::Query
+ *   db.prepare_argv(sql, ...) { ... } -> Extralite::Query
+ *
+ * Creates a prepared query with the given SQL query in argv mode. If query
+ * parameters are given, they are bound to the query. If a block is given, it is
+ * used as a transform proc.
+ * 
+ * @param sql [String] SQL statement
+ * @return [Extralite::Query] prepared query
+ */
 VALUE Database_prepare_argv(int argc, VALUE *argv, VALUE self) {
   return Database_prepare(argc, argv, self, SYM_argv);
 }
 
+/* call-seq:
+ *   db.prepare_ary(sql) -> Extralite::Query
+ *   db.prepare_ary(sql, ...) -> Extralite::Query
+ *   db.prepare_ary(sql, ...) { ... } -> Extralite::Query
+ *
+ * Creates a prepared query with the given SQL query in ary mode. If query
+ * parameters are given, they are bound to the query. If a block is given, it is
+ * used as a transform proc.
+ * 
+ * @param sql [String] SQL statement
+ * @return [Extralite::Query] prepared query
+ */
 VALUE Database_prepare_ary(int argc, VALUE *argv, VALUE self) {
   return Database_prepare(argc, argv, self, SYM_ary);
 }
 
-/* call-seq:
- *   db.interrupt -> db
- *
- * Interrupts a long running query. This method is to be called from a different
+/* Interrupts a long running query. This method is to be called from a different
  * thread than the one running the query. Upon calling `#interrupt` the running
  * query will stop and raise an `Extralite::InterruptError` exception.
  *
  * It is not safe to call `#interrupt` on a database that is about to be closed.
- * For more information, consult the [sqlite3 API docs](https://sqlite.org/c3ref/interrupt.html).
+ * For more information, consult the [sqlite3 API
+ * docs](https://sqlite.org/c3ref/interrupt.html).
+ * 
+ * @return [Extralite::Database] database
  */
 VALUE Database_interrupt(VALUE self) {
   Database_t *db = self_to_open_database(self);
@@ -743,16 +785,19 @@ VALUE backup_cleanup(VALUE ptr) {
   return Qnil;
 }
 
-/* call-seq:
- *   db.backup(dest) -> db
- *   db.backup(dest) { |remaining, total| } -> db
- *
- * Creates a backup of the database to the given destination, which can be
+/* Creates a backup of the database to the given destination, which can be
  * either a filename or a database instance. In order to monitor the backup
  * progress you can pass a block that will be called periodically by the backup
  * method with two arguments: the remaining page count, and the total page
  * count, which can be used to display the progress to the user or to collect
  * statistics.
+ * 
+ *     db_src.backup(db_dest) do |remaining, total|
+ *       puts "Backing up #{remaining}/#{total}"
+ *     end
+ * 
+ * @param dest [String, Extralite::Database] backup destination
+ * @return [Extralite::Database] source database
  */
 VALUE Database_backup(int argc, VALUE *argv, VALUE self) {
   VALUE dst;
@@ -798,12 +843,17 @@ VALUE Database_backup(int argc, VALUE *argv, VALUE self) {
   return self;
 }
 
-/* call-seq:
- *   Extralite.runtime_status(op[, reset]) -> [value, highwatermark]
- *
- * Returns runtime status values for the given op as an array containing the
+/* Returns runtime status values for the given op as an array containing the
  * current value and the high water mark value. To reset the high water mark,
  * pass true as reset.
+ *
+ * @overload runtime_status(op)
+ *   @param op [Integer] op
+ *   @return [Array<Integer>] array containing the value and high water mark
+ * @overload runtime_status(op, reset)
+ *   @param op [Integer] op
+ *   @param reset [Integer, bool] reset flag
+ *   @return [Array<Integer>] array containing the value and high water mark
  */
 VALUE Extralite_runtime_status(int argc, VALUE* argv, VALUE self) {
   VALUE op, reset;
@@ -817,12 +867,17 @@ VALUE Extralite_runtime_status(int argc, VALUE* argv, VALUE self) {
   return rb_ary_new3(2, LONG2FIX(cur), LONG2FIX(hwm));
 }
 
-/* call-seq:
- *   db.status(op[, reset]) -> [value, highwatermark]
- *
- * Returns database status values for the given op as an array containing the
+/* Returns database status values for the given op as an array containing the
  * current value and the high water mark value. To reset the high water mark,
  * pass true as reset.
+ * 
+ * @overload status(op)
+ *   @param op [Integer] op
+ *   @return [Array<Integer>] array containing the value and high water mark
+ * @overload status(op, reset)
+ *   @param op [Integer] op
+ *   @param reset [Integer, bool] reset flag
+ *   @return [Array<Integer>] array containing the value and high water mark
  */
 VALUE Database_status(int argc, VALUE *argv, VALUE self) {
   VALUE op, reset;
@@ -838,12 +893,16 @@ VALUE Database_status(int argc, VALUE *argv, VALUE self) {
   return rb_ary_new3(2, INT2NUM(cur), INT2NUM(hwm));
 }
 
-/* call-seq:
- *   db.limit(category) -> value
- *   db.limit(category, new_value) -> prev_value
- *
- * Returns the current limit for the given category. If a new value is given,
+/* Returns the current limit for the given category. If a new value is given,
  * sets the limit to the new value and returns the previous value.
+ * 
+ * @overload limit(category)
+ *   @param category [Integer] category
+ *   @return [Integer] limit value
+ * @overload limit(category, new_value)
+ *   @param category [Integer] category
+ *   @param new_value [Integer] new value
+ *   @return [Integer] old value
  */
 VALUE Database_limit(int argc, VALUE *argv, VALUE self) {
   VALUE category, new_value;
@@ -859,9 +918,7 @@ VALUE Database_limit(int argc, VALUE *argv, VALUE self) {
   return INT2NUM(value);
 }
 
-/* call-seq: db.busy_timeout=(sec) -> db db.busy_timeout=nil -> db
- *
- * Sets the busy timeout for the database, in seconds or fractions thereof. To
+/* Sets the busy timeout for the database, in seconds or fractions thereof. To
  * disable the busy timeout, set it to 0 or nil. When the busy timeout is set to
  * a value larger than zero, running a query when the database is locked will
  * cause the program to wait for the database to become available. If the
@@ -884,10 +941,7 @@ VALUE Database_busy_timeout_set(VALUE self, VALUE sec) {
   return self;
 }
 
-/* call-seq:
- *   db.total_changes -> value
- *
- * Returns the total number of changes made to the database since opening it.
+/* Returns the total number of changes made to the database since opening it.
  * 
  * @return [Integer] total changes
  */
@@ -898,12 +952,8 @@ VALUE Database_total_changes(VALUE self) {
   return INT2NUM(value);
 }
 
-/* call-seq:
- *   db.trace { |sql| } -> db
- *   db.trace -> db
- *
- * Installs or removes a block that will be invoked for every SQL statement
- * executed.
+/* Installs or removes a block that will be invoked for every SQL statement
+ * executed. To stop tracing, call `#trace` without a block.
  * 
  * @return [Extralite::Database] database
  */
@@ -961,11 +1011,7 @@ void Database_reset_progress_handler(VALUE self, Database_t *db) {
   sqlite3_busy_handler(db->sqlite3_db, NULL, NULL);
 }
 
-/* call-seq:
- *   db.on_progress(period) { } -> db
- *   db.on_progress(0) -> db
- *
- * Installs or removes a progress handler that will be executed periodically
+/* Installs or removes a progress handler that will be executed periodically
  * while a query is running. This method can be used to support switching
  * between fibers and threads or implementing timeouts for running queries.
  *
@@ -1034,10 +1080,7 @@ VALUE Database_on_progress(VALUE self, VALUE period) {
   return self;
 }
 
-/* call-seq:
- *   db.errcode -> errcode
- *
- * Returns the last error code for the database.
+/* Returns the last error code for the database.
  * 
  * @return [Integer] last error code
  */
@@ -1047,10 +1090,7 @@ VALUE Database_errcode(VALUE self) {
   return INT2NUM(sqlite3_errcode(db->sqlite3_db));
 }
 
-/* call-seq:
- *   db.errmsg -> errmsg
- *
- * Returns the last error message for the database.
+/* Returns the last error message for the database.
  * 
  * @return [String] last error message
  */
@@ -1061,10 +1101,7 @@ VALUE Database_errmsg(VALUE self) {
 }
 
 #ifdef HAVE_SQLITE3_ERROR_OFFSET
-/* call-seq:
- *   db.error_offset -> ofs
- *
- * Returns the offset for the last error. This is useful for indicating where in
+/* Returns the offset for the last error. This is useful for indicating where in
  * the SQL string an error was encountered.
  * 
  * @return [Integer] offset in the last submitted SQL string

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -245,7 +245,7 @@ static inline VALUE Database_perform_query(int argc, VALUE *argv, VALUE self, VA
 
   bind_all_parameters(stmt, argc - 1, argv + 1);
   query_ctx ctx = QUERY_CTX(
-    self, db, stmt, Qnil, transform, transform_mode, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS
+    self, db, stmt, Qnil, transform, transform_mode, ROW_YIELD_OR_MODE(ROW_MULTI), ALL_ROWS
   );
   
   return rb_ensure(SAFE(call), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
@@ -528,7 +528,7 @@ VALUE Database_batch_execute(VALUE self, VALUE sql, VALUE parameters) {
   if (RSTRING_LEN(sql) == 0) return Qnil;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, ROW_MULTI, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_execute), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -563,7 +563,7 @@ VALUE Database_batch_query(VALUE self, VALUE sql, VALUE parameters) {
   sqlite3_stmt *stmt;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, ROW_MULTI, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_query), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -598,7 +598,7 @@ VALUE Database_batch_query_ary(VALUE self, VALUE sql, VALUE parameters) {
   sqlite3_stmt *stmt;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, ROW_MULTI, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_query_ary), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -633,7 +633,7 @@ VALUE Database_batch_query_single_column(VALUE self, VALUE sql, VALUE parameters
   sqlite3_stmt *stmt;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, ROW_MULTI, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_query_single_column), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -917,7 +917,7 @@ int Database_progress_handler(void *ptr) {
 
 int Database_busy_handler(void *ptr, int v) {
   Database_t *db = (Database_t *)ptr;
-  rb_funcall(db->progress_handler_proc, ID_call, 0);
+  rb_funcall(db->progress_handler_proc, ID_call, 1, Qtrue);
   return 1;
 }
 

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -633,7 +633,7 @@ VALUE Database_load_extension(VALUE self, VALUE path) {
 static inline VALUE Database_prepare(int argc, VALUE *argv, VALUE self, VALUE mode) {
   rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
 
-  VALUE args[3] = { self, argv[0], mode};
+  VALUE args[] = { self, argv[0], mode};
   VALUE query = rb_funcall_passing_block(cQuery, ID_new, 3, args);
   if (argc > 1) rb_funcallv(query, ID_bind, argc - 1, argv + 1);
   RB_GC_GUARD(query);

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -630,35 +630,35 @@ VALUE Database_load_extension(VALUE self, VALUE path) {
 }
 #endif
 
+static inline VALUE Database_prepare(int argc, VALUE *argv, VALUE self, VALUE mode) {
+  rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
+
+  VALUE args[3] = { self, argv[0], mode};
+  VALUE query = rb_funcall_passing_block(cQuery, ID_new, 3, args);
+  if (argc > 1) rb_funcallv(query, ID_bind, argc - 1, argv + 1);
+  RB_GC_GUARD(query);
+  return query;
+}
+
 /* call-seq:
  *   db.prepare(sql) -> Extralite::Query
  *   db.prepare(sql, ...) -> Extralite::Query
+ *   db.prepare(sql) { ... } -> Extralite::Query
  *
- * Creates a prepared statement with the given SQL query. If query parameters
- * are given, they are bound to the query.
+ * Creates a prepared statement with the given SQL query in hash mode. If query
+ * parameters are given, they are bound to the query. If a block is given, it is
+ * used as a transform proc.
  */
 VALUE Database_prepare_hash(int argc, VALUE *argv, VALUE self) {
-  rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
-  VALUE query = rb_funcall(cQuery, ID_new, 3, self, argv[0], SYM_hash);
-  if (argc > 1) rb_funcallv(query, ID_bind, argc - 1, argv + 1);
-  RB_GC_GUARD(query);
-  return query;
+  return Database_prepare(argc, argv, self, SYM_hash);
 }
 
 VALUE Database_prepare_argv(int argc, VALUE *argv, VALUE self) {
-  rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
-  VALUE query = rb_funcall(cQuery, ID_new, 3, self, argv[0], SYM_argv);
-  if (argc > 1) rb_funcallv(query, ID_bind, argc - 1, argv + 1);
-  RB_GC_GUARD(query);
-  return query;
+  return Database_prepare(argc, argv, self, SYM_argv);
 }
 
 VALUE Database_prepare_ary(int argc, VALUE *argv, VALUE self) {
-  rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
-  VALUE query = rb_funcall(cQuery, ID_new, 3, self, argv[0], SYM_ary);
-  if (argc > 1) rb_funcallv(query, ID_bind, argc - 1, argv + 1);
-  RB_GC_GUARD(query);
-  return query;
+  return Database_prepare(argc, argv, self, SYM_ary);
 }
 
 /* call-seq:

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -231,7 +231,7 @@ static inline VALUE Database_perform_query(int argc, VALUE *argv, VALUE self, VA
   RB_GC_GUARD(sql);
 
   bind_all_parameters(stmt, argc - 1, argv + 1);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, Qnil, Qnil, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, Qnil, Qnil, TRANSFORM_NONE, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS);
   
   return rb_ensure(SAFE(call), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -423,7 +423,7 @@ VALUE Database_batch_execute(VALUE self, VALUE sql, VALUE parameters) {
   if (RSTRING_LEN(sql) == 0) return Qnil;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, QUERY_MULTI_ROW, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_execute), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -458,7 +458,7 @@ VALUE Database_batch_query(VALUE self, VALUE sql, VALUE parameters) {
   sqlite3_stmt *stmt;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, QUERY_MULTI_ROW, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_query), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -493,7 +493,7 @@ VALUE Database_batch_query_ary(VALUE self, VALUE sql, VALUE parameters) {
   sqlite3_stmt *stmt;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, QUERY_MULTI_ROW, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_query_ary), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -528,7 +528,7 @@ VALUE Database_batch_query_single_column(VALUE self, VALUE sql, VALUE parameters
   sqlite3_stmt *stmt;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, TRANSFORM_NONE, QUERY_MULTI_ROW, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_query_single_column), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -726,7 +726,7 @@ VALUE Database_load_extension(VALUE self, VALUE path) {
  */
 VALUE Database_prepare(int argc, VALUE *argv, VALUE self) {
   rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
-  VALUE query = rb_funcall(cQuery, ID_new, 2, self, argv[0]);
+  VALUE query = rb_funcall(cQuery, ID_new, 3, self, argv[0], SYM_hash);
   if (argc > 1) rb_funcallv(query, ID_bind, argc - 1, argv + 1);
   RB_GC_GUARD(query);
   return query;

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -231,7 +231,7 @@ static inline VALUE Database_perform_query(int argc, VALUE *argv, VALUE self, VA
   RB_GC_GUARD(sql);
 
   bind_all_parameters(stmt, argc - 1, argv + 1);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, Qnil, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, Qnil, Qnil, QUERY_MODE(QUERY_MULTI_ROW), ALL_ROWS);
   
   return rb_ensure(SAFE(call), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -423,7 +423,7 @@ VALUE Database_batch_execute(VALUE self, VALUE sql, VALUE parameters) {
   if (RSTRING_LEN(sql) == 0) return Qnil;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, QUERY_MULTI_ROW, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_execute), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -458,7 +458,7 @@ VALUE Database_batch_query(VALUE self, VALUE sql, VALUE parameters) {
   sqlite3_stmt *stmt;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, QUERY_MULTI_ROW, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_query), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -493,7 +493,7 @@ VALUE Database_batch_query_ary(VALUE self, VALUE sql, VALUE parameters) {
   sqlite3_stmt *stmt;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, QUERY_MULTI_ROW, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_query_ary), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }
@@ -528,7 +528,7 @@ VALUE Database_batch_query_single_column(VALUE self, VALUE sql, VALUE parameters
   sqlite3_stmt *stmt;
 
   prepare_single_stmt(DB_GVL_MODE(db), db->sqlite3_db, &stmt, sql);
-  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, QUERY_MULTI_ROW, ALL_ROWS);
+  query_ctx ctx = QUERY_CTX(self, db, stmt, parameters, Qnil, QUERY_MULTI_ROW, ALL_ROWS);
 
   return rb_ensure(SAFE(safe_batch_query_single_column), (VALUE)&ctx, SAFE(cleanup_stmt), (VALUE)&ctx);
 }

--- a/ext/extralite/database.c
+++ b/ext/extralite/database.c
@@ -384,12 +384,38 @@ VALUE Database_query_single_row(int argc, VALUE *argv, VALUE self) {
   return Database_perform_query(argc, argv, self, safe_query_single_row);
 }
 
+/* call-seq:
+ *   db.query_transform_hash_single_row(transform, sql, *parameters) -> {...}
+ *
+ * Runs a query returning a single row using the given transform proc to
+ * transform the row. The row is passed to the transform proc as a hash.
+ *
+ *     transform = ->(h) { MyModel.new(h) }
+ *     db.query_transform_hash_single_row(transform, 'select * from foo where x = ?', 42)
+ *
+ * @param transform [Proc] transform proc
+ * @param sql [String] SQL query string
+ * @return [any] transformed row
+ */
 VALUE Database_query_transform_hash_single_row(int argc, VALUE *argv, VALUE self) {
   if (argc < 2)
     rb_raise(eArgumentError, "Invalid arguments");
   return Database_perform_query_transform(argc - 1, argv + 1, self, safe_query_single_row, argv[0], TRANSFORM_HASH);
 }
 
+/* call-seq:
+ *   db.query_transform_argv_single_row(transform, sql, *parameters) -> {...}
+ *
+ * Runs a query returning a single row using the given transform proc to
+ * transform the row. The row is passed to the transform proc as a list of values.
+ *
+ *     transform = ->(a, b, c) { "#{a} #{b} #{c}" }
+ *     db.query_transform_argv_single_row(transform, 'select a, b, c from foo where x = ?', 42)
+ *
+ * @param transform [Proc] transform proc
+ * @param sql [String] SQL query string
+ * @return [any] transformed row
+ */
 VALUE Database_query_transform_argv_single_row(int argc, VALUE *argv, VALUE self) {
   if (argc < 2)
     rb_raise(eArgumentError, "Invalid arguments");

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -58,6 +58,12 @@ enum transform_mode {
   TRANSFORM_ARGV
 };
 
+enum query_mode {
+  QUERY_HASH,
+  QUERY_ARGV,
+  QUERY_ARY
+};
+
 typedef struct {
   VALUE               db;
   VALUE               sql;
@@ -67,6 +73,7 @@ typedef struct {
   sqlite3_stmt        *stmt;
   int                 eof;
   int                 closed;
+  enum query_mode     query_mode;
   enum transform_mode transform_mode;
 } Query_t;
 

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -74,7 +74,6 @@ typedef struct {
   int                 eof;
   int                 closed;
   enum query_mode     query_mode;
-  enum transform_mode transform_mode;
 } Query_t;
 
 enum iterator_mode {
@@ -86,7 +85,6 @@ enum iterator_mode {
 
 typedef struct {
   VALUE               query;
-  enum iterator_mode  mode;
 } Iterator_t;
 
 #ifdef EXTRALITE_ENABLE_CHANGESET
@@ -111,7 +109,8 @@ typedef struct {
   sqlite3_stmt        *stmt;
 
   int                 gvl_release_threshold;
-  enum transform_mode transform_mode;
+  // enum transform_mode transform_mode;
+  enum query_mode     query_mode;
   enum row_mode       row_mode;
   int                 max_rows;
 
@@ -128,14 +127,14 @@ enum gvl_mode {
 #define SINGLE_ROW -2
 #define ROW_YIELD_OR_MODE(default) (rb_block_given_p() ? ROW_YIELD : default)
 #define ROW_MULTI_P(mode) (mode == ROW_MULTI)
-#define QUERY_CTX(self, db, stmt, params, transform_proc, transform_mode, row_mode, max_rows) { \
+#define QUERY_CTX(self, db, stmt, params, transform_proc, query_mode, row_mode, max_rows) { \
   self, \
   params, \
   transform_proc, \
   db->sqlite3_db, \
   stmt, \
   db->gvl_release_threshold, \
-  transform_mode, \
+  query_mode, \
   row_mode, \
   max_rows, \
   0, \
@@ -146,8 +145,9 @@ enum gvl_mode {
 
 #define DEFAULT_GVL_RELEASE_THRESHOLD 1000
 
-
 extern rb_encoding *UTF8_ENCODING;
+
+typedef VALUE (*safe_query_impl)(query_ctx *);
 
 VALUE safe_batch_execute(query_ctx *ctx);
 VALUE safe_batch_query(query_ctx *ctx);
@@ -163,15 +163,18 @@ VALUE safe_query_single_row(query_ctx *ctx);
 VALUE safe_query_single_row_argv(query_ctx *ctx);
 VALUE safe_query_single_value(query_ctx *ctx);
 
+VALUE Query_each(VALUE self);
 VALUE Query_each_hash(VALUE self);
 VALUE Query_each_argv(VALUE self);
 VALUE Query_each_ary(VALUE self);
 VALUE Query_each_single_column(VALUE self);
 
+VALUE Query_next(int argc, VALUE *argv, VALUE self);
 VALUE Query_next_hash(int argc, VALUE *argv, VALUE self);
 VALUE Query_next_ary(int argc, VALUE *argv, VALUE self);
 VALUE Query_next_single_column(int argc, VALUE *argv, VALUE self);
 
+VALUE Query_to_a(VALUE self);
 VALUE Query_to_a_hash(VALUE self);
 VALUE Query_to_a_ary(VALUE self);
 VALUE Query_to_a_single_column(VALUE self);

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -40,6 +40,7 @@ extern ID ID_strip;
 extern ID ID_to_s;
 extern ID ID_track;
 
+extern VALUE SYM_argv;
 extern VALUE SYM_ary;
 extern VALUE SYM_hash;
 extern VALUE SYM_single_column;
@@ -71,6 +72,7 @@ typedef struct {
 
 enum iterator_mode {
   ITERATOR_HASH,
+  ITERATOR_ARGV,
   ITERATOR_ARY,
   ITERATOR_SINGLE_COLUMN
 };
@@ -130,15 +132,18 @@ VALUE safe_batch_execute(query_ctx *ctx);
 VALUE safe_batch_query(query_ctx *ctx);
 VALUE safe_batch_query_ary(query_ctx *ctx);
 VALUE safe_batch_query_single_column(query_ctx *ctx);
+VALUE safe_query_argv(query_ctx *ctx);
 VALUE safe_query_ary(query_ctx *ctx);
 VALUE safe_query_changes(query_ctx *ctx);
 VALUE safe_query_columns(query_ctx *ctx);
 VALUE safe_query_hash(query_ctx *ctx);
 VALUE safe_query_single_column(query_ctx *ctx);
 VALUE safe_query_single_row(query_ctx *ctx);
+VALUE safe_query_single_row_argv(query_ctx *ctx);
 VALUE safe_query_single_value(query_ctx *ctx);
 
 VALUE Query_each_hash(VALUE self);
+VALUE Query_each_argv(VALUE self);
 VALUE Query_each_ary(VALUE self);
 VALUE Query_each_single_column(VALUE self);
 
@@ -149,6 +154,8 @@ VALUE Query_next_single_column(int argc, VALUE *argv, VALUE self);
 VALUE Query_to_a_hash(VALUE self);
 VALUE Query_to_a_ary(VALUE self);
 VALUE Query_to_a_single_column(VALUE self);
+
+VALUE Query_transform_argv(VALUE self);
 
 void prepare_single_stmt(enum gvl_mode mode, sqlite3 *db, sqlite3_stmt **stmt, VALUE sql);
 void prepare_multi_stmt(enum gvl_mode mode, sqlite3 *db, sqlite3_stmt **stmt, VALUE sql);

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -43,7 +43,6 @@ extern ID ID_track;
 extern VALUE SYM_argv;
 extern VALUE SYM_ary;
 extern VALUE SYM_hash;
-extern VALUE SYM_single_column;
 
 typedef struct {
   sqlite3 *sqlite3_db;
@@ -51,12 +50,6 @@ typedef struct {
   VALUE   progress_handler_proc;
   int     gvl_release_threshold;
 } Database_t;
-
-enum transform_mode {
-  TRANSFORM_NONE,
-  TRANSFORM_HASH,
-  TRANSFORM_ARGV
-};
 
 enum query_mode {
   QUERY_HASH,
@@ -109,7 +102,6 @@ typedef struct {
   sqlite3_stmt        *stmt;
 
   int                 gvl_release_threshold;
-  // enum transform_mode transform_mode;
   enum query_mode     query_mode;
   enum row_mode       row_mode;
   int                 max_rows;
@@ -151,35 +143,20 @@ typedef VALUE (*safe_query_impl)(query_ctx *);
 
 VALUE safe_batch_execute(query_ctx *ctx);
 VALUE safe_batch_query(query_ctx *ctx);
+VALUE safe_batch_query_argv(query_ctx *ctx);
 VALUE safe_batch_query_ary(query_ctx *ctx);
-VALUE safe_batch_query_single_column(query_ctx *ctx);
 VALUE safe_query_argv(query_ctx *ctx);
 VALUE safe_query_ary(query_ctx *ctx);
 VALUE safe_query_changes(query_ctx *ctx);
 VALUE safe_query_columns(query_ctx *ctx);
 VALUE safe_query_hash(query_ctx *ctx);
-VALUE safe_query_single_column(query_ctx *ctx);
-VALUE safe_query_single_row(query_ctx *ctx);
+VALUE safe_query_single_row_hash(query_ctx *ctx);
 VALUE safe_query_single_row_argv(query_ctx *ctx);
-VALUE safe_query_single_value(query_ctx *ctx);
+VALUE safe_query_single_row_ary(query_ctx *ctx);
 
 VALUE Query_each(VALUE self);
-VALUE Query_each_hash(VALUE self);
-VALUE Query_each_argv(VALUE self);
-VALUE Query_each_ary(VALUE self);
-VALUE Query_each_single_column(VALUE self);
-
 VALUE Query_next(int argc, VALUE *argv, VALUE self);
-VALUE Query_next_hash(int argc, VALUE *argv, VALUE self);
-VALUE Query_next_ary(int argc, VALUE *argv, VALUE self);
-VALUE Query_next_single_column(int argc, VALUE *argv, VALUE self);
-
 VALUE Query_to_a(VALUE self);
-VALUE Query_to_a_hash(VALUE self);
-VALUE Query_to_a_ary(VALUE self);
-VALUE Query_to_a_single_column(VALUE self);
-
-VALUE Query_transform_argv(VALUE self);
 
 void prepare_single_stmt(enum gvl_mode mode, sqlite3 *db, sqlite3_stmt **stmt, VALUE sql);
 void prepare_multi_stmt(enum gvl_mode mode, sqlite3 *db, sqlite3_stmt **stmt, VALUE sql);

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -54,6 +54,7 @@ typedef struct {
 typedef struct {
   VALUE         db;
   VALUE         sql;
+  VALUE         convert_proc;
   Database_t    *db_struct;
   sqlite3       *sqlite3_db;
   sqlite3_stmt  *stmt;
@@ -90,6 +91,7 @@ typedef struct {
   sqlite3         *sqlite3_db;
   sqlite3_stmt    *stmt;
   VALUE           params;
+  VALUE           convert_proc;
   enum query_mode mode;
   int             max_rows;
   int             eof;
@@ -106,8 +108,8 @@ enum gvl_mode {
 #define SINGLE_ROW -2
 #define QUERY_MODE(default) (rb_block_given_p() ? QUERY_YIELD : default)
 #define MULTI_ROW_P(mode) (mode == QUERY_MULTI_ROW)
-#define QUERY_CTX(self, db, stmt, params, mode, max_rows) \
-  { self, db->sqlite3_db, stmt, params, mode, max_rows, 0, db->gvl_release_threshold, 0 }
+#define QUERY_CTX(self, db, stmt, params, convert_proc, mode, max_rows) \
+  { self, db->sqlite3_db, stmt, params, convert_proc, mode, max_rows, 0, db->gvl_release_threshold, 0 }
 #define TRACE_SQL(db, sql) \
     if (db->trace_proc != Qnil) rb_funcall(db->trace_proc, ID_call, 1, sql);
 

--- a/ext/extralite/extralite.h
+++ b/ext/extralite/extralite.h
@@ -51,15 +51,22 @@ typedef struct {
   int     gvl_release_threshold;
 } Database_t;
 
+enum transform_mode {
+  TRANSFORM_NONE,
+  TRANSFORM_HASH,
+  TRANSFORM_ARGV
+};
+
 typedef struct {
-  VALUE         db;
-  VALUE         sql;
-  VALUE         convert_proc;
-  Database_t    *db_struct;
-  sqlite3       *sqlite3_db;
-  sqlite3_stmt  *stmt;
-  int           eof;
-  int           closed;
+  VALUE               db;
+  VALUE               sql;
+  VALUE               transform_proc;
+  Database_t          *db_struct;
+  sqlite3             *sqlite3_db;
+  sqlite3_stmt        *stmt;
+  int                 eof;
+  int                 closed;
+  enum transform_mode transform_mode;
 } Query_t;
 
 enum iterator_mode {
@@ -87,16 +94,17 @@ enum query_mode {
 };
 
 typedef struct {
-  VALUE           self;
-  sqlite3         *sqlite3_db;
-  sqlite3_stmt    *stmt;
-  VALUE           params;
-  VALUE           convert_proc;
-  enum query_mode mode;
-  int             max_rows;
-  int             eof;
-  int             gvl_release_threshold;
-  int             step_count;
+  VALUE               self;
+  sqlite3             *sqlite3_db;
+  sqlite3_stmt        *stmt;
+  VALUE               params;
+  VALUE               transform_proc;
+  enum transform_mode transform_mode;
+  enum query_mode     mode;
+  int                 max_rows;
+  int                 eof;
+  int                 gvl_release_threshold;
+  int                 step_count;
 } query_ctx;
 
 enum gvl_mode {
@@ -108,8 +116,8 @@ enum gvl_mode {
 #define SINGLE_ROW -2
 #define QUERY_MODE(default) (rb_block_given_p() ? QUERY_YIELD : default)
 #define MULTI_ROW_P(mode) (mode == QUERY_MULTI_ROW)
-#define QUERY_CTX(self, db, stmt, params, convert_proc, mode, max_rows) \
-  { self, db->sqlite3_db, stmt, params, convert_proc, mode, max_rows, 0, db->gvl_release_threshold, 0 }
+#define QUERY_CTX(self, db, stmt, params, transform_proc, transform_mode, query_mode, max_rows) \
+  { self, db->sqlite3_db, stmt, params, transform_proc, transform_mode, query_mode, max_rows, 0, db->gvl_release_threshold, 0 }
 #define TRACE_SQL(db, sql) \
     if (db->trace_proc != Qnil) rb_funcall(db->trace_proc, ID_call, 1, sql);
 

--- a/ext/extralite/iterator.c
+++ b/ext/extralite/iterator.c
@@ -10,6 +10,7 @@
 VALUE cIterator;
 
 VALUE SYM_hash;
+VALUE SYM_argv;
 VALUE SYM_ary;
 VALUE SYM_single_column;
 
@@ -46,8 +47,9 @@ static inline Iterator_t *self_to_iterator(VALUE obj) {
 }
 
 static inline enum iterator_mode symbol_to_mode(VALUE sym) {
-  if (sym == SYM_hash) return ITERATOR_HASH;
-  if (sym == SYM_ary) return ITERATOR_ARY;
+  if (sym == SYM_hash)          return ITERATOR_HASH;
+  if (sym == SYM_argv)          return ITERATOR_ARGV;
+  if (sym == SYM_ary)           return ITERATOR_ARY;
   if (sym == SYM_single_column) return ITERATOR_SINGLE_COLUMN;
 
   rb_raise(cError, "Invalid iterator mode");
@@ -78,6 +80,8 @@ typedef VALUE (*each_method)(VALUE);
 
 inline each_method mode_to_each_method(enum iterator_mode mode) {
   switch (mode) {
+    case ITERATOR_ARGV:
+      return Query_each_argv;
     case ITERATOR_ARY:
       return Query_each_ary;
     case ITERATOR_SINGLE_COLUMN:
@@ -204,10 +208,12 @@ void Init_ExtraliteIterator(void) {
   rb_define_method(cIterator, "to_a", Iterator_to_a, 0);
 
   SYM_hash          = ID2SYM(rb_intern("hash"));
+  SYM_argv          = ID2SYM(rb_intern("argv"));
   SYM_ary           = ID2SYM(rb_intern("ary"));
   SYM_single_column = ID2SYM(rb_intern("single_column"));
 
   rb_gc_register_mark_object(SYM_hash);
+  rb_gc_register_mark_object(SYM_argv);
   rb_gc_register_mark_object(SYM_ary);
   rb_gc_register_mark_object(SYM_single_column);
 }

--- a/ext/extralite/iterator.c
+++ b/ext/extralite/iterator.c
@@ -9,11 +9,6 @@
 
 VALUE cIterator;
 
-VALUE SYM_hash;
-VALUE SYM_argv;
-VALUE SYM_ary;
-VALUE SYM_single_column;
-
 static size_t Iterator_size(const void *ptr) {
   return sizeof(Iterator_t);
 }
@@ -138,14 +133,4 @@ void Init_ExtraliteIterator(void) {
   rb_define_method(cIterator, "inspect", Iterator_inspect, 0);
   rb_define_method(cIterator, "next", Iterator_next, -1);
   rb_define_method(cIterator, "to_a", Iterator_to_a, 0);
-
-  SYM_hash          = ID2SYM(rb_intern("hash"));
-  SYM_argv          = ID2SYM(rb_intern("argv"));
-  SYM_ary           = ID2SYM(rb_intern("ary"));
-  SYM_single_column = ID2SYM(rb_intern("single_column"));
-
-  rb_gc_register_mark_object(SYM_hash);
-  rb_gc_register_mark_object(SYM_argv);
-  rb_gc_register_mark_object(SYM_ary);
-  rb_gc_register_mark_object(SYM_single_column);
 }

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -585,11 +585,20 @@ VALUE Query_inspect(VALUE self) {
   return rb_sprintf("#<%"PRIsVALUE":%p %"PRIsVALUE">", cname, (void*)self, sql);
 }
 
+/* Returns the query mode.
+ *
+ * @return [Symbol] query mode
+ */
 VALUE Query_mode_get(VALUE self) {
   Query_t *query = self_to_query(self);
   return query_mode_to_symbol(query->query_mode);
 }
 
+/* Sets the query mode. This can be one of `:hash`, `:argv`, `:ary`.
+ *
+ * @param [Symbol] query mode
+ * @return [Symbol] query mode
+ */
 VALUE Query_mode_set(VALUE self, VALUE mode) {
   Query_t *query = self_to_query(self);
   query->query_mode = symbol_to_query_mode(mode);

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -14,6 +14,10 @@ VALUE cQuery;
 ID ID_inspect;
 ID ID_slice;
 
+VALUE SYM_hash;
+VALUE SYM_argv;
+VALUE SYM_ary;
+
 #define DB_GVL_MODE(query) Database_prepare_gvl_mode(query->db_struct)
 
 static size_t Query_size(const void *ptr) {
@@ -620,4 +624,12 @@ void Init_ExtraliteQuery(void) {
 
   ID_inspect  = rb_intern("inspect");
   ID_slice    = rb_intern("slice");
+
+  SYM_hash          = ID2SYM(rb_intern("hash"));
+  SYM_argv          = ID2SYM(rb_intern("argv"));
+  SYM_ary           = ID2SYM(rb_intern("ary"));
+
+  rb_gc_register_mark_object(SYM_hash);
+  rb_gc_register_mark_object(SYM_argv);
+  rb_gc_register_mark_object(SYM_ary);
 }

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -488,7 +488,12 @@ VALUE Query_columns(VALUE self) {
  */
 VALUE Query_clone(VALUE self) {
   Query_t *query = self_to_query(self);
-  return rb_funcall(cQuery, ID_new, 3, query->db, query->sql, query_mode_to_symbol(query->query_mode));
+  VALUE args[] = {
+    query->db,
+    query->sql,
+    query_mode_to_symbol(query->query_mode)
+  };
+  return rb_funcall_with_block(cQuery, ID_new, 3, args, query->transform_proc);
 }
 
 /* Closes the query. Attempting to run a closed query will raise an error.

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -106,6 +106,8 @@ VALUE Query_initialize(VALUE self, VALUE db, VALUE sql, VALUE mode) {
 
   RB_OBJ_WRITE(self, &query->db, db);
   RB_OBJ_WRITE(self, &query->sql, sql);
+  if (rb_block_given_p())
+    RB_OBJ_WRITE(self, &query->transform_proc, rb_block_proc());
 
   query->db = db;
   query->db_struct = self_to_database(db);

--- a/ext/extralite/query.c
+++ b/ext/extralite/query.c
@@ -193,12 +193,12 @@ static inline VALUE Query_perform_next(VALUE self, int max_rows, VALUE (*call)(q
     Qnil,
     query->transform_proc,
     transform ? query->transform_mode : TRANSFORM_NONE,
-    QUERY_MODE(max_rows == SINGLE_ROW ? QUERY_SINGLE_ROW : QUERY_MULTI_ROW),
+    ROW_YIELD_OR_MODE(max_rows == SINGLE_ROW ? ROW_SINGLE : ROW_MULTI),
     MAX_ROWS(max_rows)
   );
   VALUE result = call(&ctx);
   query->eof = ctx.eof;
-  return (ctx.mode == QUERY_YIELD) ? self : result;
+  return (ctx.row_mode == ROW_YIELD) ? self : result;
 }
 
 #define MAX_ROWS_FROM_ARGV(argc, argv) (argc == 1 ? FIX2INT(argv[0]) : SINGLE_ROW)
@@ -470,7 +470,7 @@ VALUE Query_batch_execute(VALUE self, VALUE parameters) {
     parameters,
     Qnil,
     TRANSFORM_NONE,
-    QUERY_MODE(QUERY_MULTI_ROW),
+    ROW_YIELD_OR_MODE(ROW_MULTI),
     ALL_ROWS
   );
   return safe_batch_execute(&ctx);
@@ -518,7 +518,7 @@ VALUE Query_batch_query_hash(VALUE self, VALUE parameters) {
     parameters,
     query->transform_proc,
     query->transform_mode,
-    QUERY_MODE(QUERY_MULTI_ROW),
+    ROW_YIELD_OR_MODE(ROW_MULTI),
     ALL_ROWS
   );
   return safe_batch_query(&ctx);
@@ -564,7 +564,7 @@ VALUE Query_batch_query_ary(VALUE self, VALUE parameters) {
     parameters,
     Qnil,
     TRANSFORM_NONE,
-    QUERY_MODE(QUERY_MULTI_ROW),
+    ROW_YIELD_OR_MODE(ROW_MULTI),
     ALL_ROWS
   );
   return safe_batch_query_ary(&ctx);
@@ -610,7 +610,7 @@ VALUE Query_batch_query_single_column(VALUE self, VALUE parameters) {
     parameters,
     Qnil,
     TRANSFORM_NONE,
-    QUERY_MODE(QUERY_MULTI_ROW),
+    ROW_YIELD_OR_MODE(ROW_MULTI),
     ALL_ROWS
   );
   return safe_batch_query_single_column(&ctx);

--- a/lib/extralite.rb
+++ b/lib/extralite.rb
@@ -46,7 +46,7 @@ module Extralite
     # @param db [String] name of attached database
     # @return [Array] list of tables
     def tables(db = 'main')
-      query_single_column(format(TABLES_SQL, db: db))
+      query_argv(format(TABLES_SQL, db: db))
     end
 
     # Gets or sets one or more database pragmas. For a list of available pragmas
@@ -150,7 +150,7 @@ module Extralite
     end
 
     def pragma_get(key)
-      query_single_value("pragma #{key}")
+      query_single_argv("pragma #{key}")
     end
   end
 

--- a/lib/extralite.rb
+++ b/lib/extralite.rb
@@ -81,13 +81,12 @@ module Extralite
     # @param mode [Symbol, String] transaction mode (deferred, immediate or exclusive).
     # @return [Any] the given block's return value
     def transaction(mode = :immediate)
-      execute "begin #{mode} transaction"
-    
       abort = false
+      execute "begin #{mode} transaction"    
       yield self
     rescue => e
       abort = true
-      raise unless e.is_a?(Rollback)
+      e.is_a?(Rollback) ? nil : raise
     ensure
       execute(abort ? 'rollback' : 'commit')
     end

--- a/test/perf_argv_transform.rb
+++ b/test/perf_argv_transform.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Run on Ruby 3.3 with YJIT enabled
+
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'extralite', path: '..'
+  gem 'benchmark-ips'
+end
+
+require 'benchmark/ips'
+require 'fileutils'
+
+DB_PATH = "/tmp/extralite_sqlite3_perf-#{Time.now.to_i}-#{rand(10000)}.db"
+puts "DB_PATH = #{DB_PATH.inspect}"
+
+$extralite_db = Extralite::Database.new(DB_PATH, gvl_release_threshold: -1)
+
+def prepare_database(count)
+  $extralite_db.query('create table if not exists foo ( a integer primary key, b text )')
+  $extralite_db.query('delete from foo')
+  $extralite_db.query('begin')
+  count.times { $extralite_db.query('insert into foo (b) values (?)', "hello#{rand(1000)}" )}
+  $extralite_db.query('commit')
+end
+
+class Model
+  def initialize(h)
+    @h = h
+  end
+
+  def values
+    @h
+  end
+end
+
+TRANSFORM = ->(a, b) { { a: a, b: b } }
+
+def extralite_run_map(count)
+  results = []
+  $extralite_db.query_ary('select * from foo') { |(a, b)| results << { a: a, b: b } }
+  raise unless results.size == count
+end
+
+def extralite_run_transform(count)
+  results = $extralite_db.query_transform_argv(TRANSFORM, 'select * from foo')
+  raise unless results.size == count
+end
+
+[10, 1000, 100000].each do |c|
+  puts "Record count: #{c}"
+  prepare_database(c)
+
+  bm = Benchmark.ips do |x|
+    x.config(:time => 5, :warmup => 2)
+
+    x.report("map")       { extralite_run_map(c) }
+    x.report("transform") { extralite_run_transform(c) }
+
+    x.compare!
+  end
+  puts;
+  bm.entries.each { |e| puts "#{e.label}: #{(e.ips * c).round.to_i} rows/s" }
+  puts;
+end

--- a/test/perf_hash_transform.rb
+++ b/test/perf_hash_transform.rb
@@ -44,7 +44,7 @@ def extralite_run_map(count)
 end
 
 def extralite_run_transform(count)
-  results = $extralite_db.query_transform_hash(TRANSFORM, 'select * from foo')
+  results = $extralite_db.query(TRANSFORM, 'select * from foo')
   raise unless results.size == count
 end
 

--- a/test/perf_hash_transform.rb
+++ b/test/perf_hash_transform.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Run on Ruby 3.3 with YJIT enabled
+
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'extralite', path: '..'
+  gem 'benchmark-ips'
+end
+
+require 'benchmark/ips'
+require 'fileutils'
+
+DB_PATH = "/tmp/extralite_sqlite3_perf-#{Time.now.to_i}-#{rand(10000)}.db"
+puts "DB_PATH = #{DB_PATH.inspect}"
+
+$extralite_db = Extralite::Database.new(DB_PATH, gvl_release_threshold: -1)
+
+def prepare_database(count)
+  $extralite_db.query('create table if not exists foo ( a integer primary key, b text )')
+  $extralite_db.query('delete from foo')
+  $extralite_db.query('begin')
+  count.times { $extralite_db.query('insert into foo (b) values (?)', "hello#{rand(1000)}" )}
+  $extralite_db.query('commit')
+end
+
+class Model
+  def initialize(h)
+    @h = h
+  end
+
+  def values
+    @h
+  end
+end
+
+TRANSFORM = ->(h) { Model.new(h) }
+
+def extralite_run_map(count)
+  results = $extralite_db.query('select * from foo').map(&TRANSFORM)
+  raise unless results.size == count
+end
+
+def extralite_run_transform(count)
+  results = $extralite_db.query_transform_hash(TRANSFORM, 'select * from foo')
+  raise unless results.size == count
+end
+
+[10, 1000, 100000].each do |c|
+  puts "Record count: #{c}"
+  prepare_database(c)
+
+  bm = Benchmark.ips do |x|
+    x.config(:time => 5, :warmup => 2)
+
+    x.report("map")       { extralite_run_map(c) }
+    x.report("transform") { extralite_run_transform(c) }
+
+    x.compare!
+  end
+  puts;
+  bm.entries.each { |e| puts "#{e.label}: #{(e.ips * c).round.to_i} rows/s" }
+  puts;
+end

--- a/test/perf_polyphony.rb
+++ b/test/perf_polyphony.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Run on Ruby 3.3 with YJIT enabled
+
+require 'bundler/inline'
+gemfile do
+  gem 'polyphony'
+  gem 'extralite', path: '.'
+  gem 'benchmark-ips'
+end
+
+require 'benchmark/ips'
+require 'polyphony'
+
+DB_PATH = "/tmp/extralite_sqlite3_perf-#{Time.now.to_i}-#{rand(10000)}.db"
+puts "DB_PATH = #{DB_PATH.inspect}"
+
+$db1 = Extralite::Database.new(DB_PATH, gvl_release_threshold: -1)
+$db2 = Extralite::Database.new(DB_PATH, gvl_release_threshold: 0)
+$db3 = Extralite::Database.new(DB_PATH)
+
+$snooze_count = 0
+$db3.on_progress(25) { $snooze_count += 1; snooze }
+
+def prepare_database(count)
+  $db1.execute('create table if not exists foo ( a integer primary key, b text )')
+  $db1.transaction do
+    $db1.execute('delete from foo')
+    rows = count.times.map { "hello#{rand(1000)}" }
+    $db1.batch_execute('insert into foo (b) values (?)', rows)
+  end
+end
+
+def extralite_run1(count)
+  results = $db1.query('select * from foo')
+  raise unless results.size == count
+end
+
+def extralite_run2(count)
+  results = $db2.query('select * from foo')
+  raise unless results.size == count
+end
+
+def extralite_run3(count)
+  results = $db3.query('select * from foo')
+  raise unless results.size == count
+end
+
+[10, 1000, 100000].each do |c|
+  puts "Record count: #{c}"
+  prepare_database(c)
+
+  bm = Benchmark.ips do |x|
+    x.config(:time => 3, :warmup => 1)
+
+    x.report('GVL threshold -1') { extralite_run1(c) }
+    x.report('GVL threshold  0') { extralite_run2(c) }
+    $snooze_count  = 0
+    x.report('on_progress 1000') { extralite_run3(c) }
+
+    x.compare!
+  end
+  puts;
+  bm.entries.each do |e|
+    score = (e.ips * c).round.to_i
+    if e.label == 'on_progress 1000'
+      snooze_rate = ($snooze_count / e.seconds).to_i
+      puts "#{e.label}: #{score} rows/s  snoozes: #{snooze_rate} i/s"
+    else
+      puts "#{e.label}: #{score} rows/s"
+    end
+  end
+  puts;
+end

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -967,6 +967,30 @@ class DatabaseTest < MiniTest::Test
       { x: 4, y: 5, z: 6}
     ], q.to_a
   end
+
+  def test_prepare_with_transform
+    q = @db.prepare('select * from t order by x') { |h| h[:x] * 100 + h[:y] * 10 + h[:z] }
+    assert_equal [
+      123,
+      456
+    ], q.to_a
+  end
+
+  def test_prepare_argv_with_transform
+    q = @db.prepare_argv('select * from t order by x') { |x, y, z| x * 100 + y * 10 + z }
+    assert_equal [
+      123,
+      456
+    ], q.to_a
+  end
+
+  def test_prepare_ary_with_transform
+    q = @db.prepare_ary('select * from t order by x') { |r| r * 2 }
+    assert_equal [
+      [1, 2, 3, 1, 2, 3],
+      [4, 5, 6, 4, 5, 6]
+    ], q.to_a
+  end
 end
 
 class ScenarioTest < MiniTest::Test

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -61,6 +61,12 @@ class DatabaseTest < MiniTest::Test
     assert_equal [[1, 2, 3], [4, 5, 6]], r
   end
 
+  def test_query_argv_with_too_many_columns
+    assert_raises(Extralite::Error) {
+      @db.query_argv('select 1, 2, 3, 4, 5, 6, 7, 8, 9');
+    }
+  end
+
   def test_query_single
     r = @db.query_single('select * from t order by x desc limit 1')
     assert_equal({ x: 4, y: 5, z: 6 }, r)
@@ -965,6 +971,25 @@ class DatabaseTest < MiniTest::Test
     assert_equal [
       { x: 1, y: 2, z: 3},
       { x: 4, y: 5, z: 6}
+    ], q.to_a
+  end
+
+  def test_prepare_argv
+    q = @db.prepare_argv('select * from t order by x')
+    assert_kind_of Extralite::Query, q
+
+    buf = []
+    q.each { |x, y, z| buf << z }
+    assert_equal [3, 6], buf
+  end
+
+  def test_prepare_ary
+    q = @db.prepare_ary('select * from t order by x')
+    assert_kind_of Extralite::Query, q
+
+    assert_equal [
+      [1, 2, 3],
+      [4, 5, 6]
     ], q.to_a
   end
 

--- a/test/test_iterator.rb
+++ b/test/test_iterator.rb
@@ -30,6 +30,16 @@ class IteratorTest < MiniTest::Test
     assert_equal [{x: 1, y: 2, z: 3},{ x: 4, y: 5, z: 6 }, { x: 7, y: 8, z: 9 }], buf
   end
 
+  def test_iterator_argv
+    iter = @query.each_argv
+    assert_kind_of Extralite::Iterator, iter
+
+    buf = []
+    v = iter.each { |a, b, c| buf << [a, b, c] }
+    assert_equal iter, v
+    assert_equal [[1, 2, 3], [4, 5, 6], [7, 8, 9]], buf
+  end
+
   def test_iterator_ary
     iter = @query.each_ary
     assert_kind_of Extralite::Iterator, iter

--- a/test/test_iterator.rb
+++ b/test/test_iterator.rb
@@ -31,7 +31,8 @@ class IteratorTest < MiniTest::Test
   end
 
   def test_iterator_argv
-    iter = @query.each_argv
+    @query.mode = :argv
+    iter = @query.each
     assert_kind_of Extralite::Iterator, iter
 
     buf = []
@@ -41,7 +42,8 @@ class IteratorTest < MiniTest::Test
   end
 
   def test_iterator_ary
-    iter = @query.each_ary
+    @query.mode = :ary
+    iter = @query.each
     assert_kind_of Extralite::Iterator, iter
 
     buf = []
@@ -51,8 +53,8 @@ class IteratorTest < MiniTest::Test
   end
 
   def test_iterator_single_column
-    query = @db.prepare('select x from t')
-    iter = query.each_single_column
+    query = @db.prepare_argv('select x from t')
+    iter = query.each
     assert_kind_of Extralite::Iterator, iter
 
     buf = []
@@ -69,14 +71,15 @@ class IteratorTest < MiniTest::Test
     assert_nil iter.next
     assert_nil iter.next
 
-    iter = @query.reset.each_ary
+    @query.mode = :ary
+    @query.reset
     assert_equal([1, 2, 3], iter.next)
     assert_equal([4, 5, 6], iter.next)
     assert_equal([7, 8, 9], iter.next)
     assert_nil iter.next
     assert_nil iter.next
 
-    iter = @db.prepare('select y from t').each_single_column
+    iter = @db.prepare_argv('select y from t').each
     assert_equal(2, iter.next)
     assert_equal(5, iter.next)
     assert_equal(8, iter.next)
@@ -88,10 +91,10 @@ class IteratorTest < MiniTest::Test
     iter = @query.each
     assert_equal [{x: 1, y: 2, z: 3},{ x: 4, y: 5, z: 6 }, { x: 7, y: 8, z: 9 }], iter.to_a
 
-    iter = @query.each_ary
+    @query.mode = :ary
     assert_equal [[1, 2, 3], [4, 5, 6], [7, 8, 9]], iter.to_a
 
-    iter = @db.prepare('select x from t').each_single_column
+    iter = @db.prepare_argv('select x from t').each
     assert_equal [1, 4, 7], iter.to_a
   end
 
@@ -99,17 +102,19 @@ class IteratorTest < MiniTest::Test
     mapped = @query.each.map { |row| row[:x] * 10 }
     assert_equal [10, 40, 70], mapped
 
-    mapped = @query.each_ary.map { |row| row[1] * 10 }
+    @query.mode = :ary
+    mapped = @query.each.map { |row| row[1] * 10 }
     assert_equal [20, 50, 80], mapped
 
-    query = @db.prepare('select z from t')
-    mapped = query.each_single_column.map { |v| v * 10 }
+    query = @db.prepare_argv('select z from t')
+    mapped = query.each.map { |v| v * 10 }
     assert_equal [30, 60, 90], mapped
   end
 
   def test_iterator_inspect
-    i = @query.each_ary
-    assert_match /^\#\<Extralite::Iterator:0x[0-9a-f]+ ary\>$/, i.inspect
+    @query.mode = :ary
+    i = @query.each
+    assert_match /^\#\<Extralite::Iterator:0x[0-9a-f]+\>$/, i.inspect
   end
 
   def test_return_from_block_issue_26

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -1042,6 +1042,39 @@ class QueryTransformTest < MiniTest::Test
     ], buf
   end
 
+  def test_transform_ary
+    @q5.mode = :ary
+    q = @q5.transform { |h| MyModel.new(h) }
+    assert_equal @q5, q
+
+    o = @q5.bind(1).next
+    assert_kind_of MyModel, o
+    assert_equal([1, 2], o.values)
+
+    o = @q5.bind(4).next
+    assert_kind_of MyModel, o
+    assert_equal([4, 5], o.values)
+
+    assert_equal [
+      [[1, 2]],
+      [[4, 5]]
+    ], @q5.batch_query([[1], [4]]).map { |a| a.map(&:values) }
+
+    @q6.mode = :ary
+    @q6.transform { |h| MyModel.new(h) }
+    assert_equal [
+      [1, 2],
+      [4, 5]
+    ], @q6.to_a.map(&:values)
+
+    buf = []
+    @q6.each { |r| buf << r.values }
+    assert_equal [
+      [1, 2],
+      [4, 5]
+    ], buf
+  end
+
   def test_transform_argv_single_column
     q = @q1.transform { |c| JSON.parse(c, symbolize_names: true) }
     assert_equal @q1, q

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -920,7 +920,7 @@ class QueryTest < MiniTest::Test
   end
 end
 
-class QueryConvertTest < MiniTest::Test
+class QueryTransformTest < MiniTest::Test
   def setup
     @db = Extralite::Database.new(':memory:')
     @db.query('create table t (a, b, c)')

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -24,6 +24,23 @@ class QueryTest < MiniTest::Test
     assert_equal 4, query.next_single_column
   end
 
+  def test_mode
+    query = @db.prepare('select 1')
+    assert_equal :hash, query.mode
+    
+    query.mode = :argv
+    assert_equal :argv, query.mode
+
+    query.mode = :ary
+    assert_equal :ary, query.mode
+
+    assert_raises(Extralite::Error) { query.mode = :foo }
+    assert_equal :ary, query.mode
+
+    query.mode = :hash
+    assert_equal :hash, query.mode
+  end
+
   def test_query_props
     assert_kind_of Extralite::Query, @query
     assert_equal @db, @query.database

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -937,8 +937,8 @@ class QueryConvertTest < MiniTest::Test
     ])
   end
 
-  def test_convert_single_column
-    q = @q1.convert { |c| JSON.parse(c, symbolize_names: true) }
+  def test_transform_argv_single_column
+    q = @q1.transform_argv { |c| JSON.parse(c, symbolize_names: true) }
     assert_equal @q1, q
 
     assert_equal({ foo: 42, bar: 43 }, @q1.bind(1).next)
@@ -949,7 +949,7 @@ class QueryConvertTest < MiniTest::Test
       [{ foo: 45, bar: 46 }]
     ], @q1.batch_query([[1], [4]])
 
-    @q2.convert { |c| JSON.parse(c, symbolize_names: true) }
+    @q2.transform_argv { |c| JSON.parse(c, symbolize_names: true) }
     assert_equal [
       { foo: 42, bar: 43 },
       { foo: 45, bar: 46 }
@@ -963,8 +963,8 @@ class QueryConvertTest < MiniTest::Test
     ], buf
   end
 
-  def test_convert_multi_column
-    q = @q3.convert { |a, b, c| { a: a, b: b, c: JSON.parse(c, symbolize_names: true) } }
+  def test_transform_argv_multi_column
+    q = @q3.transform_argv { |a, b, c| { a: a, b: b, c: JSON.parse(c, symbolize_names: true) } }
     assert_equal @q3, q
 
     assert_equal({ a: 1, b: 2, c: { foo: 42, bar: 43 }}, @q3.bind(1).next)
@@ -975,7 +975,7 @@ class QueryConvertTest < MiniTest::Test
       [{ a: 4, b: 5, c: { foo: 45, bar: 46 }}]
     ], @q3.batch_query([[1], [4]])
 
-    @q4.convert { |a, b, c| { a: a, b: b, c: JSON.parse(c, symbolize_names: true) } }
+    @q4.transform_argv { |a, b, c| { a: a, b: b, c: JSON.parse(c, symbolize_names: true) } }
     assert_equal [
       { a: 1, b: 2, c: { foo: 42, bar: 43 }},
       { a: 4, b: 5, c: { foo: 45, bar: 46 }}


### PR DESCRIPTION
This PR streamlines the different query APIs, adds value transforms and introduces a new `argv` mode:

```ruby
transform = ->(h) { MyModel.new(h) }
db.query(transform, 'select * from foo')

transform = ->(a, b, c) { { a: a, b: b, c: JSON.parse(c) } }
db.query_argv(transform, 'select a, b, c from foo')

# transforms on prepared queries
q = db.prepare('select * from foo') { |h| MyModel.new(h) }
q.to_a #=> transformed rows

q = db.prepare_argv('select a, b, c from foo') { |a, b, c| { a: a, b: b, c: JSON.parse(c) } }
q.to_a #=> transformed rows
```

The `#query_argv` method can be significantly faster than `#query_ary`, but more benchmarks are needed. All in all the transforms in themselves don't really change much in terms of performance, it's more of a convenience.